### PR TITLE
Fix path issue for forwarder version

### DIFF
--- a/hack/app_sre_build_deploy.sh
+++ b/hack/app_sre_build_deploy.sh
@@ -31,8 +31,8 @@ skopeo copy --dest-creds "${QUAY_USER}:${QUAY_TOKEN}" \
     "docker-daemon:${FORWARDER_IMG}" \
     "docker://${QUAY_FORWARDER_IMAGE}:latest"
 
-FORWARDER_VERSION=$(grep FORWARDER_VERSION= ../project.mk | awk -F= '{print $2 }')
-FORWARDER_HASH=$(grep FORWARDER_HASH= ../project.mk | awk -F= '{print $2 }')
+FORWARDER_VERSION=$(grep FORWARDER_VERSION= project.mk | awk -F= '{print $2 }')
+FORWARDER_HASH=$(grep FORWARDER_HASH= project.mk | awk -F= '{print $2 }')
 
 skopeo copy --dest-creds "${QUAY_USER}:${QUAY_TOKEN}" \
     "docker-daemon:${FORWARDER_IMG}" \


### PR DESCRIPTION
This PR fixes the path issue when grep'ing for the forwarder version. The build pipline executes `app_sre_build_deploy.sh` from the root level not from within the `./hack` dir.