### PR TITLE
Use status.infrastructurename instead of clustername

### DIFF
--- a/pkg/controller/splunkforwarder/splunkforwarder_controller.go
+++ b/pkg/controller/splunkforwarder/splunkforwarder_controller.go
@@ -108,7 +108,7 @@ func (r *ReconcileSplunkForwarder) Reconcile(request reconcile.Request) (reconci
 			reqLogger.Info(err.Error())
 			clusterid = "openshift"
 		} else {
-			clusterid = configFound.ClusterName
+			clusterid = configFound.Status.InfrastructureName
 		}
 	}
 


### PR DESCRIPTION
Seems clustername can be blank so use status.infrastructurename

/cc @jharrington22 