### PR TITLE
Update debug node log path

### DIFF
--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -261,7 +261,7 @@ objects:
           index: openshift_managed_audit
           whitelist: \.log$
           sourcetype: _json
-        - path: /host/var/log/containers/ip-*-*-*-*ec2internal-debug*.log
+        - path: /host/var/log/pods/*_ip-*-*-*-*ec2internal-debug_*/container-*/*.log
           index: openshift_managed_debug_node
           whitelist: \.log$
           sourcetype: _json


### PR DESCRIPTION
The previous path was a full path symlink pointing to /var, however it could not find it as the filesystem is under /host, so I updated the path to point to then none symlinkd file.

/cc @jharrington22 