### PR TITLE
Node debug logs are not json

### DIFF
--- a/deploy/crds/splunkforwarder_v1alpha1_splunkforwarder_cr.yaml
+++ b/deploy/crds/splunkforwarder_v1alpha1_splunkforwarder_cr.yaml
@@ -15,4 +15,4 @@ spec:
   - path: /host/var/log/containers/ip-*-*-*-*ec2internal-debug*.log
     index: openshift_managed_debug_node
     whitelist: \.log$
-    sourcetype: _json
+    sourcetype: openshift:debug


### PR DESCRIPTION
Seems they are not JSON :/ so use a custom sourcetype for the node debug logs