### PR TITLE
Including logs for pod creation and positive scan results

### DIFF
--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -284,6 +284,14 @@ objects:
           index: openshift_managed_debug_node
           whiteList: \.log$
           sourceType: openshift:debug
+        - path: /host/var/log/pods/openshift-scanning-operator_logger*/logger/*.log
+          index: openshift_managed_pod_creation
+          whiteList: \.log$
+          sourceType: _json
+        - path: /host/var/log/openshift_managed_malware_scan.log
+          index: openshift_managed_malware_scan
+          whiteList: \.log$
+          sourceType: _json
 
 - apiVersion: hive.openshift.io/v1alpha1
   kind: SelectorSyncSet


### PR DESCRIPTION
These two rules map to two new splunk indices. I split the positive scan results into their own file as there will be far fewer entries for those.