### PR TITLE
switching to dedicated pod creation log file

### DIFF
--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -288,7 +288,7 @@ objects:
           index: openshift_managed_debug_node
           whiteList: \.log$
           sourceType: openshift:debug
-        - path: /host/var/log/pods/openshift-scanning-operator_logger*/logger/*.log
+        - path: /host/var/log/openshift_managed_pod_creation.log
           index: openshift_managed_pod_creation
           whiteList: \.log$
           sourceType: _json


### PR DESCRIPTION
Pod creation logs are now being written to their own dedicated log file.