### PR TITLE
Filters initial

### DIFF
--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -275,6 +275,13 @@ objects:
         heavyForwarderSelector: infra
         useHeavyForwarder: true
         splunkLicenseAccepted: true
+        filters:
+        - name: ignore_serviceaccount_users
+          filter: '"user":{"username":"(?:system:serviceaccount:[^"]+)".*"userAgent":"(?:(?![^"]*(Mozilla|oc|Wget|curl)[^"]*/)[^"]+)'
+        - name: ignore_system_node_users
+          filter: '"user":{"username":"system:node:[^"]+"'
+        - name: ignore_chatty_system_users
+          filter: '"user":{"username":"system:(?:kube-(?:controller-manager|scheduler)|api-server)"'
         splunkInputs:
         - path: /host/var/log/openshift-apiserver/audit.log
           index: openshift_managed_audit

--- a/pkg/kube/configmaps.go
+++ b/pkg/kube/configmaps.go
@@ -129,6 +129,10 @@ defaultGroup = internal
 [tcpout:internal]
 server = ` + instance.Name + `:9997
 `,
+			"limits.conf": `
+[thruput]
+maxKBps = 0
+`,
 		},
 	}
 
@@ -144,8 +148,16 @@ access = read : [ * ], write : [ admin ]
 export = system
 `
 	data["inputs.conf"] = `
+[splunktcp]
+route = has_key:_replicationBucketUUID:replicationQueue;has_key:_dstrx:typingQueue;has_key:_linebreaker:typingQueue;absent_key:_linebreaker:parsingQueue
+
 [splunktcp://:9997]
 connection_host = dns
+`
+
+	data["limits.conf"] = `
+[thruput]
+maxKBps = 0
 `
 	if len(instance.Spec.Filters) > 0 {
 		data["transforms.conf"] = ""


### PR DESCRIPTION
This change addresses [OSD-2091](https://issues.redhat.com/browse/OSD-2091) and [OSD-3571](https://issues.redhat.com/browse/OSD-3571).

The "thruput" bit was suggested by Splunk support. The route bit is the default with `has_key:_linebreaker:...` changed from `indexQueue` to `typingQueue`.

One can get the default route with `$SPLUNK_HOME/bin/splunk cmd btool inputs list --debug`