### PR TITLE
Clean up logs

### DIFF
--- a/containers/forwarder/Dockerfile
+++ b/containers/forwarder/Dockerfile
@@ -19,7 +19,9 @@ RUN microdnf install -y libsemanage shadow-utils findutils procps wget && \
     mkdir -p /opt/splunkforwarder/etc/apps/splunkauth/{default,local,metadata} && \
     chown -R splunk:splunk /opt/splunkforwarder && \
     chown -R splunk:splunk /run.sh && \
-    chmod +x /run.sh
+    chmod +x /run.sh && \
+    sed -i 's/\.maxBackupIndex=5/\.maxBackupIndex=1/g' /opt/splunkforwarder/etc/log.cfg && \
+    sed -i 's/\.maxFileSize=25000000/\.maxFileSize=250000/g' /opt/splunkforwarder/etc/log.cfg
 
 USER splunk
 CMD [ "/run.sh" ]

--- a/containers/heavy_forwarder/Dockerfile
+++ b/containers/heavy_forwarder/Dockerfile
@@ -21,8 +21,9 @@ RUN microdnf install -y libsemanage shadow-utils findutils procps wget && \
     chown -R splunk:splunk /run.sh && \
     chmod +x /run.sh && \
     echo -e "\nOPTIMISTIC_ABOUT_FILE_LOCKING = 1" >>  /opt/splunk/etc/splunk-launch.conf && \
-    sed -i 's/startwebserver = 1/startwebserver = 0/' /opt/splunk/etc/system/default/web.conf
-
+    sed -i 's/startwebserver = 1/startwebserver = 0/' /opt/splunk/etc/system/default/web.conf && \
+    sed -i 's/\.maxBackupIndex=5/\.maxBackupIndex=1/g' /opt/splunk/etc/log.cfg && \
+    sed -i 's/\.maxFileSize=25000000/\.maxFileSize=250000/g' /opt/splunk/etc/log.cfg
 
 USER splunk
 CMD [ "/run.sh" ]

--- a/pkg/kube/deployment.go
+++ b/pkg/kube/deployment.go
@@ -72,6 +72,10 @@ func GenerateDeployment(instance *sfv1alpha1.SplunkForwarder) *appsv1.Deployment
 					},
 					TerminationGracePeriodSeconds: &terminationGracePeriodSeconds,
 
+					NodeSelector: map[string]string{
+						"node-role.kubernetes.io": selector,
+					},
+
 					Containers: []corev1.Container{
 						{
 							Name:            "splunk-hf",


### PR DESCRIPTION
Reduce the amount of on disk logs to help prevent disks from filling up.
Ensure the HF's land on the correct nodes as specified in the CR.