### PR TITLE
OSD-5077 Lock registry image in 4.5

### DIFF
--- a/hack/app_sre_create_image_catalog.sh
+++ b/hack/app_sre_create_image_catalog.sh
@@ -91,7 +91,7 @@ REGISTRY_IMG="quay.io/app-sre/splunk-forwarder-operator-registry"
 DOCKERFILE_REGISTRY="Dockerfile.olm-registry"
 
 cat <<EOF > $DOCKERFILE_REGISTRY
-FROM quay.io/openshift/origin-operator-registry:latest
+FROM quay.io/openshift/origin-operator-registry:4.5
 
 COPY $SAAS_OPERATOR_DIR manifests
 RUN initializer --permissive


### PR DESCRIPTION
### What type of PR is this? 
_(bug/feature/cleanup/docs/design/test/chore/refactor..)_
Bug
### What this PR does / why we need it:
Openshift-registry introduced a breaking change in 4.6 in their docker image, locking img tag in 4.5

### Which issue(s) this PR fixes(can be a reference to existing issue or jira/bz):
OSD-5077
