### PR TITLE
Update yq syntax and fix saas file location

### DIFF
--- a/hack/app_sre_create_image_catalog.sh
+++ b/hack/app_sre_create_image_catalog.sh
@@ -2,6 +2,10 @@
 
 set -exv
 
+# prefix var with _ so we don't clober the var used during the Make build
+# it probably doesn't matter but we can change it later.
+_OPERATOR_NAME="splunk-forwarder-operator"
+
 BRANCH_CHANNEL="$1"
 QUAY_IMAGE="$2"
 
@@ -23,8 +27,8 @@ git clone \
 REMOVED_VERSIONS=""
 if [[ "$REMOVE_UNDEPLOYED" == true ]]; then
     DEPLOYED_HASH=$(
-        curl -s "https://gitlab.cee.redhat.com/service/app-interface/raw/master/data/services/osd-operators/cicd/saas/saas-splunk-forwarder-operator.yaml" | \
-            docker run --rm -i quay.io/app-sre/yq -r '.resourceTemplates[]|select(.name="splunk-forwarder-operator").targets[]|select(.namespace["$ref"]=="/services/osd-operators/namespaces/hive-production-cluster-scope.yml")|.ref'
+        curl -s "https://gitlab.cee.redhat.com/service/app-interface/raw/master/data/services/osd-operators/cicd/saas/saas-${_OPERATOR_NAME}.yaml" | \
+            docker run --rm -i quay.io/app-sre/yq yq r - "resourceTemplates[*].targets(namespace.\$ref==/services/osd-operators/namespaces/hivep01ue1/cluster-scope.yml).ref"
     )
 
     delete=false


### PR DESCRIPTION
The image used for yq was change to be the golang version which has a completely different syntax to the original python version. The entry point for the container is also not correct hence needing the extra yq.

The path to discover what version of the operator promoted to production has changed in app-interface, this has been updated.