### PR TITLE
Forward the 4.6 oauth-apiserver audit logs to the managed audit index

### DIFF
--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -291,6 +291,10 @@ objects:
           index: openshift_managed_audit
           whiteList: \.log$
           sourceType: _json
+        - path: /host/var/log/oauth-apiserver/audit.log
+          index: openshift_managed_audit
+          whiteList: \.log$
+          sourceType: _json
         - path: /host/var/log/pods/*_ip-*-*-*-*ec2internal-debug_*/container-*/*.log
           index: openshift_managed_debug_node
           whiteList: \.log$


### PR DESCRIPTION
Adds the new oauth server audit logs the managed cluster SSS

These logs are identical in structure to the other apiserver logs