### PR TITLE
Add report status from OSD operators to OCM

### DIFF
--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -12,11 +12,18 @@ parameters:
   value: latest
 - name: ALERTS_SKIP_LEGALENTITY_IDS
   value: '["none"]'
+- name: OPERATOR_NAME
+  value: splunk-forwarder-operator
+  required: true
 
 objects:
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:
+    annotations:
+      component-display-name: Splunk Forwarder Operator
+      component-name: ${OPERATOR_NAME}
+      telemeter-query: csv_succeeded{_id="$CLUSTER_ID",name=~"${OPERATOR_NAME}.*",exported_namespace=~"openshift-.*",namespace="openshift-operator-lifecycle-manager"} == 1
     name: splunk-forwarder-operator-sss
     namespace: splunk-forwarder-operator
   spec:


### PR DESCRIPTION
Part of https://issues.redhat.com/browse/SDE-591

parsing the template using `oc process --local -f` looks like this:

```
"telemeter-query": "csv_succeeded{_id=\"$CLUSTER_ID\",name=~\"splunk-forwarder-operator.*\",exported_namespace=~\"openshift-.*\",namespace=\"openshift-operator-lifecycle-manager\"} == 1"
```

The `CLUSTER_ID` parameter is not going to be replaced via this template, but from OCM.