### PR TITLE
Set mount propagation mode for host volume

### DIFF
--- a/pkg/kube/volumemounts.go
+++ b/pkg/kube/volumemounts.go
@@ -10,6 +10,7 @@ import (
 // gets mounted in the container
 func GetVolumeMounts(instance *sfv1alpha1.SplunkForwarder) []corev1.VolumeMount {
 	var forwarderConfig string
+	var mountPropagationMode = corev1.MountPropagationHostToContainer
 	if instance.Spec.UseHeavyForwarder {
 		forwarderConfig = instance.Name + "-internalsplunk"
 	} else {
@@ -42,9 +43,10 @@ func GetVolumeMounts(instance *sfv1alpha1.SplunkForwarder) []corev1.VolumeMount 
 
 		// Host Mount
 		{
-			Name:      "host",
-			MountPath: "/host",
-			ReadOnly:  true,
+			Name:             "host",
+			MountPath:        "/host",
+			MountPropagation: &mountPropagationMode,
+			ReadOnly:         true,
 		},
 	}
 }

--- a/pkg/kube/volumemounts_test.go
+++ b/pkg/kube/volumemounts_test.go
@@ -14,6 +14,7 @@ func TestGetVolumeMounts(t *testing.T) {
 	type args struct {
 		instance *sfv1alpha1.SplunkForwarder
 	}
+	var mountPropagationMode = corev1.MountPropagationHostToContainer
 	tests := []struct {
 		name string
 		args args
@@ -53,9 +54,10 @@ func TestGetVolumeMounts(t *testing.T) {
 					MountPath: "/opt/splunkforwarder/etc/apps/osd_monitored_logs/metadata",
 				},
 				{
-					Name:      "host",
-					MountPath: "/host",
-					ReadOnly:  true,
+					Name:             "host",
+					MountPath:        "/host",
+					MountPropagation: &mountPropagationMode,
+					ReadOnly:         true,
 				},
 			},
 		},
@@ -93,9 +95,10 @@ func TestGetVolumeMounts(t *testing.T) {
 					MountPath: "/opt/splunkforwarder/etc/apps/osd_monitored_logs/metadata",
 				},
 				{
-					Name:      "host",
-					MountPath: "/host",
-					ReadOnly:  true,
+					Name:             "host",
+					MountPath:        "/host",
+					MountPropagation: &mountPropagationMode,
+					ReadOnly:         true,
 				},
 			},
 		},


### PR DESCRIPTION
To allow access to access pod volumes mounted after the forwarder pod has started