### PR TITLE
Support splunk-[heavy]forwarder pulls by digest

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ metadata:
   name: example-splunkforwarder
 spec:
   image: dockerimageurl
-  imageTag: "versiontag"
+  imageDigest: "sha256:8c4a2a8bb186c6b0ea744fd4c05df61d2c50053ebf42a0a6ec7aef8170be4c55"
   splunkLicenseAccepted: true
   clusterID: optional-cluster-name
   splunkInputs:
@@ -34,8 +34,20 @@ spec:
     sourcetype: _json
 ```
 
-The image and imageTag are for the image in /forwarder (currently version 
-8.0.5-a1a6394cc5ae)
+The `image` and `imageDigest` are for the [splunk-forwarder image](containers/forwarder/).
+If `useHeavyForwarder` is `true`, `heavyForwarderImage` and `heavyForwarderDigest` are used for the [splunk-heavyforwarder image](containers/heavy_forwarder/).
+(The CRD supports `imageTag` for both, but this is deprecated.)
+To use the current version, `8.0.5-a1a6394cc5ae`, specify the following:
+- For [splunk-forwarder](https://quay.io/repository/app-sre/splunk-forwarder?tag=8.0.5-a1a6394cc5ae&tab=tags):
+  ```yaml
+  image: quay.io/app-sre/splunk-forwarder
+  imageDigest: sha256:2452a3f01e840661ee1194777ed5a9185ceaaa9ec7329ed364fa2f02be22a701
+  ```
+- For [splunk-heavyforwarder](https://quay.io/repository/app-sre/splunk-heavyforwarder?tag=8.0.5-a1a6394cc5ae&tab=tags):
+  ```yaml
+  heavyForwarderImage: quay.io/app-sre/splunk-heavyforwarder
+  heavyForwarderDigest: sha256:49b40c2c5d79913efb7eff9f3bf9c7348e322f619df10173e551b2596913d52a
+  ```
 
 ## Testing the app-sre pipeline
 

--- a/deploy/crds/splunkforwarder.managed.openshift.io_splunkforwarders_crd.yaml
+++ b/deploy/crds/splunkforwarder.managed.openshift.io_splunkforwarders_crd.yaml
@@ -42,6 +42,8 @@ spec:
                   - name
                 type: object
               type: array
+            heavyForwarderDigest:
+              type: string
             heavyForwarderImage:
               type: string
             heavyForwarderReplicas:
@@ -50,6 +52,8 @@ spec:
             heavyForwarderSelector:
               type: string
             image:
+              type: string
+            imageDigest:
               type: string
             imageTag:
               type: string
@@ -77,7 +81,6 @@ spec:
               type: boolean
           required:
             - image
-            - imageTag
             - splunkInputs
           type: object
         status:

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 )
 
 require (
+	github.com/google/go-cmp v0.4.0
 	github.com/operator-framework/operator-sdk v0.16.0
 	k8s.io/api v0.0.0
 	k8s.io/apimachinery v0.0.0

--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -292,8 +292,9 @@ objects:
         namespace: openshift-security
       spec:
         image: quay.io/app-sre/splunk-forwarder
-        imageTag: 8.0.5-a1a6394cc5ae
+        imageDigest: sha256:2452a3f01e840661ee1194777ed5a9185ceaaa9ec7329ed364fa2f02be22a701
         heavyForwarderImage: quay.io/app-sre/splunk-heavyforwarder
+        heavyForwarderDigest: sha256:49b40c2c5d79913efb7eff9f3bf9c7348e322f619df10173e551b2596913d52a
         heavyForwarderSelector: infra
         useHeavyForwarder: true
         splunkLicenseAccepted: true
@@ -356,8 +357,9 @@ objects:
         namespace: openshift-security
       spec:
         image: quay.io/app-sre/splunk-forwarder
-        imageTag: 8.0.5-a1a6394cc5ae
+        imageDigest: sha256:2452a3f01e840661ee1194777ed5a9185ceaaa9ec7329ed364fa2f02be22a701
         heavyForwarderImage: quay.io/app-sre/splunk-heavyforwarder
+        heavyForwarderDigest: sha256:49b40c2c5d79913efb7eff9f3bf9c7348e322f619df10173e551b2596913d52a
         heavyForwarderSelector: infra
         useHeavyForwarder: true
         splunkLicenseAccepted: true

--- a/pkg/apis/splunkforwarder/v1alpha1/splunkforwarder_types.go
+++ b/pkg/apis/splunkforwarder/v1alpha1/splunkforwarder_types.go
@@ -9,12 +9,14 @@ import (
 type SplunkForwarderSpec struct {
 	SplunkLicenseAccepted  bool                    `json:"splunkLicenseAccepted,omitempty"`
 	Image                  string                  `json:"image"`
-	ImageTag               string                  `json:"imageTag"`
+	ImageTag               string                  `json:"imageTag,omitempty"`
+	ImageDigest            string                  `json:"imageDigest,omitempty"`
 	ClusterID              string                  `json:"clusterID,omitempty"`
 	// +listType=atomic
 	SplunkInputs           []SplunkForwarderInputs `json:"splunkInputs"`
 	UseHeavyForwarder      bool                    `json:"useHeavyForwarder,omitempty"`
 	HeavyForwarderImage    string                  `json:"heavyForwarderImage,omitempty"`
+	HeavyForwarderDigest   string                  `json:"heavyForwarderDigest,omitempty"`
 	HeavyForwarderReplicas int32                   `json:"heavyForwarderReplicas,omitempty"`
 	HeavyForwarderSelector string                  `json:"heavyForwarderSelector,omitempty"`
 	// +listType=map

--- a/pkg/apis/splunkforwarder/v1alpha1/zz_generated.openapi.go
+++ b/pkg/apis/splunkforwarder/v1alpha1/zz_generated.openapi.go
@@ -88,6 +88,12 @@ func schema_pkg_apis_splunkforwarder_v1alpha1_SplunkForwarderSpec(ref common.Ref
 							Format: "",
 						},
 					},
+					"imageDigest": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
+						},
+					},
 					"clusterID": {
 						SchemaProps: spec.SchemaProps{
 							Type:   []string{"string"},
@@ -118,6 +124,12 @@ func schema_pkg_apis_splunkforwarder_v1alpha1_SplunkForwarderSpec(ref common.Ref
 						},
 					},
 					"heavyForwarderImage": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
+						},
+					},
+					"heavyForwarderDigest": {
 						SchemaProps: spec.SchemaProps{
 							Type:   []string{"string"},
 							Format: "",
@@ -156,7 +168,7 @@ func schema_pkg_apis_splunkforwarder_v1alpha1_SplunkForwarderSpec(ref common.Ref
 						},
 					},
 				},
-				Required: []string{"image", "imageTag", "splunkInputs"},
+				Required: []string{"image", "splunkInputs"},
 			},
 		},
 		Dependencies: []string{

--- a/pkg/kube/daemonset.go
+++ b/pkg/kube/daemonset.go
@@ -9,6 +9,19 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+func forwarderPullSpec(instance *sfv1alpha1.SplunkForwarder) string {
+	var sep, suffix string
+	// ImageDigest takes precedence.
+	if instance.Spec.ImageDigest != "" {
+		sep = "@"
+		suffix = instance.Spec.ImageDigest
+	} else {
+		sep = ":"
+		suffix = instance.Spec.ImageTag
+	}
+	return instance.Spec.Image + sep + suffix
+}
+
 // GenerateDaemonSet returns a daemonset that can be created with the oc client
 func GenerateDaemonSet(instance *sfv1alpha1.SplunkForwarder) *appsv1.DaemonSet {
 
@@ -76,8 +89,7 @@ func GenerateDaemonSet(instance *sfv1alpha1.SplunkForwarder) *appsv1.DaemonSet {
 						{
 							Name:            "splunk-uf",
 							ImagePullPolicy: corev1.PullAlways,
-							// TEMPORARY: hardcode by-digest pull spec
-							Image: "quay.io/app-sre/splunk-forwarder@sha256:2452a3f01e840661ee1194777ed5a9185ceaaa9ec7329ed364fa2f02be22a701",
+							Image:           forwarderPullSpec(instance),
 							Ports: []corev1.ContainerPort{
 								{
 									ContainerPort: 8089,

--- a/pkg/kube/daemonset_test.go
+++ b/pkg/kube/daemonset_test.go
@@ -1,7 +1,6 @@
 package kube
 
 import (
-	"reflect"
 	"testing"
 
 	sfv1alpha1 "github.com/openshift/splunk-forwarder-operator/pkg/apis/splunkforwarder/v1alpha1"
@@ -10,214 +9,168 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-const (
-	instanceName      = "test"
-	instanceNamespace = "openshift-test"
-	image             = "test-image"
-	imageTag          = "0.0.1"
-)
-
-func TestGenerateDaemonSet(t *testing.T) {
+// daemonSetInstance produces (a pointer to) an expected DaemonSet produced by GenerateDaemonSet.
+// Parameters;
+// - sfInstance: SplunkForwarder instance under test.
+func expectedDaemonSet(instance *sfv1alpha1.SplunkForwarder) *appsv1.DaemonSet {
 	var expectedRunAsUID int64 = 0
 	var expectedIsPrivContainer bool = true
 	var expectedTerminationGracePeriodSeconds int64 = 10
-	var testHFInstance = &sfv1alpha1.SplunkForwarder{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:       instanceName,
-			Namespace:  instanceNamespace,
-			Generation: 10,
-		},
-		Spec: sfv1alpha1.SplunkForwarderSpec{
-			UseHeavyForwarder:      true,
-			HeavyForwarderReplicas: 0,
-			SplunkLicenseAccepted:  true,
-			Image:                  image,
-			ImageTag:               imageTag,
-		},
-	}
-	var testNoHFInstance = &sfv1alpha1.SplunkForwarder{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:       instanceName,
-			Namespace:  instanceNamespace,
-			Generation: 10,
-		},
-		Spec: sfv1alpha1.SplunkForwarderSpec{
-			UseHeavyForwarder:      false,
-			HeavyForwarderReplicas: 0,
-			SplunkLicenseAccepted:  true,
-			Image:                  image,
-			ImageTag:               imageTag,
-		},
+
+	useVolumeSecret := !instance.Spec.UseHeavyForwarder
+	var sfImage string
+	if instance.Spec.ImageDigest == "" {
+		sfImage = image + ":" + imageTag
+	} else {
+		sfImage = image + "@" + imageDigest
 	}
 
-	type args struct {
-		instance *sfv1alpha1.SplunkForwarder
+	return &appsv1.DaemonSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      instanceName + "-ds",
+			Namespace: instanceNamespace,
+			Labels: map[string]string{
+				"app": instanceName,
+			},
+			Annotations: map[string]string{
+				"genVersion": "10",
+			},
+		},
+		Spec: appsv1.DaemonSetSpec{
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"name": "splunk-forwarder",
+				},
+			},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "splunk-forwarder",
+					Namespace: instanceNamespace,
+					Labels: map[string]string{
+						"name": "splunk-forwarder",
+					},
+				},
+				Spec: corev1.PodSpec{
+					NodeSelector: map[string]string{
+						"beta.kubernetes.io/os": "linux",
+					},
+
+					ServiceAccountName: "default",
+					Tolerations: []corev1.Toleration{
+						{
+							Operator: corev1.TolerationOpExists,
+						},
+					},
+					TerminationGracePeriodSeconds: &expectedTerminationGracePeriodSeconds,
+
+					Containers: []corev1.Container{
+						{
+							Name:            "splunk-uf",
+							ImagePullPolicy: corev1.PullAlways,
+							Image:           sfImage,
+							Ports: []corev1.ContainerPort{
+								{
+									ContainerPort: 8089,
+									Protocol:      corev1.ProtocolTCP,
+								},
+							},
+							Resources:              corev1.ResourceRequirements{},
+							TerminationMessagePath: "/dev/termination-log",
+							Env: []corev1.EnvVar{
+								{
+									Name:  "SPLUNK_ACCEPT_LICENSE",
+									Value: "yes",
+								},
+							},
+
+							VolumeMounts: GetVolumeMounts(instance),
+
+							SecurityContext: &corev1.SecurityContext{
+								Privileged: &expectedIsPrivContainer,
+								RunAsUser:  &expectedRunAsUID,
+							},
+						},
+					},
+					Volumes: GetVolumes(true, useVolumeSecret, instanceName),
+				},
+			},
+		},
 	}
+}
+
+func TestGenerateDaemonSet(t *testing.T) {
 	tests := []struct {
-		name string
-		args args
-		want *appsv1.DaemonSet
+		name     string
+		instance *sfv1alpha1.SplunkForwarder
 	}{
+		// TODO: The following configurations should be invalid and produce a predictable error:
+		// - splunkForwarderInstance(any, false, false, any)
+		//   (Can't make sf pull spec when neither tag nor digest is present.)
 		{
-			name: "Test Daemonset with HF",
-			args: args{
-				instance: testHFInstance,
-			},
-			want: &appsv1.DaemonSet{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      instanceName + "-ds",
-					Namespace: instanceNamespace,
-					Labels: map[string]string{
-						"app": instanceName,
-					},
-					Annotations: map[string]string{
-						"genVersion": "10",
-					},
-				},
-				Spec: appsv1.DaemonSetSpec{
-					Selector: &metav1.LabelSelector{
-						MatchLabels: map[string]string{
-							"name": "splunk-forwarder",
-						},
-					},
-					Template: corev1.PodTemplateSpec{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "splunk-forwarder",
-							Namespace: instanceNamespace,
-							Labels: map[string]string{
-								"name": "splunk-forwarder",
-							},
-						},
-						Spec: corev1.PodSpec{
-							NodeSelector: map[string]string{
-								"beta.kubernetes.io/os": "linux",
-							},
-
-							ServiceAccountName: "default",
-							Tolerations: []corev1.Toleration{
-								{
-									Operator: corev1.TolerationOpExists,
-								},
-							},
-							TerminationGracePeriodSeconds: &expectedTerminationGracePeriodSeconds,
-
-							Containers: []corev1.Container{
-								{
-									Name:            "splunk-uf",
-									ImagePullPolicy: corev1.PullAlways,
-									Image:           "quay.io/app-sre/splunk-forwarder@sha256:2452a3f01e840661ee1194777ed5a9185ceaaa9ec7329ed364fa2f02be22a701",
-									Ports: []corev1.ContainerPort{
-										{
-											ContainerPort: 8089,
-											Protocol:      corev1.ProtocolTCP,
-										},
-									},
-									Resources:              corev1.ResourceRequirements{},
-									TerminationMessagePath: "/dev/termination-log",
-									Env: []corev1.EnvVar{
-										{
-											Name:  "SPLUNK_ACCEPT_LICENSE",
-											Value: "yes",
-										},
-									},
-
-									VolumeMounts: GetVolumeMounts(testHFInstance),
-
-									SecurityContext: &corev1.SecurityContext{
-										Privileged: &expectedIsPrivContainer,
-										RunAsUser:  &expectedRunAsUID,
-									},
-								},
-							},
-							Volumes: GetVolumes(true, false, instanceName),
-						},
-					},
-				},
-			},
+			name:     "Without HF, with image digest",
+			instance: splunkForwarderInstance(false, false, true, false),
 		},
 		{
-			name: "Test Daemonset without HF",
-			args: args{
-				instance: testNoHFInstance,
-			},
-			want: &appsv1.DaemonSet{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      instanceName + "-ds",
-					Namespace: instanceNamespace,
-					Labels: map[string]string{
-						"app": instanceName,
-					},
-					Annotations: map[string]string{
-						"genVersion": "10",
-					},
-				},
-				Spec: appsv1.DaemonSetSpec{
-					Selector: &metav1.LabelSelector{
-						MatchLabels: map[string]string{
-							"name": "splunk-forwarder",
-						},
-					},
-					Template: corev1.PodTemplateSpec{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "splunk-forwarder",
-							Namespace: instanceNamespace,
-							Labels: map[string]string{
-								"name": "splunk-forwarder",
-							},
-						},
-						Spec: corev1.PodSpec{
-							NodeSelector: map[string]string{
-								"beta.kubernetes.io/os": "linux",
-							},
-
-							ServiceAccountName: "default",
-							Tolerations: []corev1.Toleration{
-								{
-									Operator: corev1.TolerationOpExists,
-								},
-							},
-							TerminationGracePeriodSeconds: &expectedTerminationGracePeriodSeconds,
-
-							Containers: []corev1.Container{
-								{
-									Name:            "splunk-uf",
-									ImagePullPolicy: corev1.PullAlways,
-									Image:           "quay.io/app-sre/splunk-forwarder@sha256:2452a3f01e840661ee1194777ed5a9185ceaaa9ec7329ed364fa2f02be22a701",
-									Ports: []corev1.ContainerPort{
-										{
-											ContainerPort: 8089,
-											Protocol:      corev1.ProtocolTCP,
-										},
-									},
-									Resources:              corev1.ResourceRequirements{},
-									TerminationMessagePath: "/dev/termination-log",
-									Env: []corev1.EnvVar{
-										{
-											Name:  "SPLUNK_ACCEPT_LICENSE",
-											Value: "yes",
-										},
-									},
-
-									VolumeMounts: GetVolumeMounts(testNoHFInstance),
-
-									SecurityContext: &corev1.SecurityContext{
-										Privileged: &expectedIsPrivContainer,
-										RunAsUser:  &expectedRunAsUID,
-									},
-								},
-							},
-							Volumes: GetVolumes(true, true, instanceName),
-						},
-					},
-				},
-			},
+			name: "Without HF, with digests",
+			// The HF digest is ignored because not using HF
+			instance: splunkForwarderInstance(false, false, true, true),
+		},
+		{
+			name:     "Test Daemonset without HF, with tags",
+			instance: splunkForwarderInstance(false, true, false, false),
+		},
+		{
+			name: "Test Daemonset without HF, with tags and moot HF digest",
+			// The HF digest is ignored because not using HF
+			instance: splunkForwarderInstance(false, true, false, true),
+		},
+		{
+			name:     "Without HF, digest overrides tag",
+			instance: splunkForwarderInstance(false, true, true, false),
+		},
+		{
+			name: "Without HF, digest overrides tag, moot HF digest",
+			// The HF digest is ignored because not using HF
+			instance: splunkForwarderInstance(false, true, true, true),
+		},
+		{
+			name: "With HF, with image digest",
+			// NOTE: useHeavy && !useTag && !useHeavyDigest should be an invalid configuration,
+			// but GenerateDaemonSet won't catch that.
+			instance: splunkForwarderInstance(true, false, true, false),
+		},
+		{
+			name:     "With HF, with digests",
+			instance: splunkForwarderInstance(true, false, true, true),
+		},
+		{
+			name:     "Test Daemonset, with HF, with tags",
+			instance: splunkForwarderInstance(true, true, false, false),
+		},
+		{
+			name: "With HF, image tag and HF digest",
+			// IRL this will produce a DaemonSet with the sf image by tag, and a Deployment with
+			// the shf image by digest.
+			instance: splunkForwarderInstance(true, true, false, true),
+		},
+		{
+			name: "With HF, image digest overrides tag",
+			// IRL this will produce a DaemonSet with the sf image by digest, and a Deployment with
+			// the shf image by tag.
+			instance: splunkForwarderInstance(true, true, true, false),
+		},
+		{
+			name: "With HF, digests overrides tags",
+			// IRL this will produce a DaemonSet with the sf image by digest, and a Deployment with
+			// the shf image also by digest.
+			instance: splunkForwarderInstance(true, true, true, true),
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := GenerateDaemonSet(tt.args.instance); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("GenerateDaemonSet() = %v, want %v", got, tt.want)
-			}
+			DeepEqualWithDiff(t,
+				expectedDaemonSet(tt.instance),
+				GenerateDaemonSet(tt.instance))
 		})
 	}
 }

--- a/pkg/kube/deployment_test.go
+++ b/pkg/kube/deployment_test.go
@@ -1,7 +1,6 @@
 package kube
 
 import (
-	"reflect"
 	"testing"
 
 	sfv1alpha1 "github.com/openshift/splunk-forwarder-operator/pkg/apis/splunkforwarder/v1alpha1"
@@ -10,123 +9,135 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func TestGenerateDeployment(t *testing.T) {
+func expectedDeployment(instance *sfv1alpha1.SplunkForwarder) *appsv1.Deployment {
 	var expectedReplicas int32 = 2
 	var expectedTerminationGracePeriodSeconds int64 = 10
 	var expectedRunAsUserID int64 = 1000
-	var testInstance = &sfv1alpha1.SplunkForwarder{
+
+	var hsfImage string
+	if instance.Spec.HeavyForwarderDigest == "" {
+		hsfImage = hfImage + ":" + imageTag
+	} else {
+		hsfImage = hfImage + "@" + heavyDigest
+	}
+
+	return &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:       "test",
-			Namespace:  "openshift-test",
-			Generation: 10,
-		},
-		Spec: sfv1alpha1.SplunkForwarderSpec{
-			UseHeavyForwarder:      true,
-			HeavyForwarderReplicas: 0,
-			SplunkLicenseAccepted:  true,
-			HeavyForwarderSelector: "infra",
-			HeavyForwarderImage:    "test-image",
-			ImageTag:               "0.0.1",
-		},
-	}
-
-	type args struct {
-		instance *sfv1alpha1.SplunkForwarder
-	}
-
-	tests := []struct {
-		name string
-		args args
-		want *appsv1.Deployment
-	}{
-		{
-			name: "Heavy Forwarder deployment",
-			args: args{
-				instance: testInstance,
+			Name:      "test-deployment",
+			Namespace: "openshift-test",
+			Labels: map[string]string{
+				"app": "test",
 			},
-			want: &appsv1.Deployment{
+			Annotations: map[string]string{
+				"genVersion": "10",
+			},
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: &expectedReplicas,
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"name": "splunk-heavy-forwarder",
+				},
+			},
+			Strategy: appsv1.DeploymentStrategy{
+				Type: "RollingUpdate",
+			},
+			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-deployment",
+					Name:      "splunk-heavy-forwarder",
 					Namespace: "openshift-test",
 					Labels: map[string]string{
-						"app": "test",
-					},
-					Annotations: map[string]string{
-						"genVersion": "10",
+						"name": "splunk-heavy-forwarder",
 					},
 				},
-				Spec: appsv1.DeploymentSpec{
-					Replicas: &expectedReplicas,
-					Selector: &metav1.LabelSelector{
-						MatchLabels: map[string]string{
-							"name": "splunk-heavy-forwarder",
+				Spec: corev1.PodSpec{
+					ServiceAccountName: "default",
+					Tolerations: []corev1.Toleration{
+						{
+							Key:      "node-role.kubernetes.io/infra",
+							Operator: corev1.TolerationOpExists,
+							Effect:   corev1.TaintEffectNoSchedule,
 						},
 					},
-					Strategy: appsv1.DeploymentStrategy{
-						Type: "RollingUpdate",
+					TerminationGracePeriodSeconds: &expectedTerminationGracePeriodSeconds,
+
+					NodeSelector: map[string]string{
+						"node-role.kubernetes.io": "infra",
 					},
-					Template: corev1.PodTemplateSpec{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "splunk-heavy-forwarder",
-							Namespace: "openshift-test",
-							Labels: map[string]string{
-								"name": "splunk-heavy-forwarder",
-							},
-						},
-						Spec: corev1.PodSpec{
-							ServiceAccountName: "default",
-							Tolerations: []corev1.Toleration{
+
+					Containers: []corev1.Container{
+						{
+							Name:            "splunk-hf",
+							ImagePullPolicy: corev1.PullAlways,
+							Image:           hsfImage,
+							Ports: []corev1.ContainerPort{
 								{
-									Key:      "node-role.kubernetes.io/infra",
-									Operator: corev1.TolerationOpExists,
-									Effect:   corev1.TaintEffectNoSchedule,
+									ContainerPort: 8089,
+									Protocol:      corev1.ProtocolTCP,
 								},
 							},
-							TerminationGracePeriodSeconds: &expectedTerminationGracePeriodSeconds,
+							Resources:              corev1.ResourceRequirements{},
+							TerminationMessagePath: "/dev/termination-log",
 
-							NodeSelector: map[string]string{
-								"node-role.kubernetes.io": "infra",
-							},
-
-							Containers: []corev1.Container{
+							Env: []corev1.EnvVar{
 								{
-									Name:            "splunk-hf",
-									ImagePullPolicy: corev1.PullAlways,
-									Image:           "quay.io/app-sre/splunk-heavyforwarder@sha256:49b40c2c5d79913efb7eff9f3bf9c7348e322f619df10173e551b2596913d52a",
-									Ports: []corev1.ContainerPort{
-										{
-											ContainerPort: 8089,
-											Protocol:      corev1.ProtocolTCP,
-										},
-									},
-									Resources:              corev1.ResourceRequirements{},
-									TerminationMessagePath: "/dev/termination-log",
-
-									Env: []corev1.EnvVar{
-										{
-											Name:  "SPLUNK_ACCEPT_LICENSE",
-											Value: "yes",
-										},
-									},
-
-									VolumeMounts: GetHeavyForwarderVolumeMounts(testInstance),
+									Name:  "SPLUNK_ACCEPT_LICENSE",
+									Value: "yes",
 								},
 							},
-							Volumes: GetVolumes(false, true, "test"),
-							SecurityContext: &corev1.PodSecurityContext{
-								RunAsUser: &expectedRunAsUserID,
-							},
+
+							VolumeMounts: GetHeavyForwarderVolumeMounts(instance),
 						},
+					},
+					Volumes: GetVolumes(false, true, "test"),
+					SecurityContext: &corev1.PodSecurityContext{
+						RunAsUser: &expectedRunAsUserID,
 					},
 				},
 			},
+		},
+	}
+}
+
+func TestGenerateDeployment(t *testing.T) {
+
+	tests := []struct {
+		name     string
+		instance *sfv1alpha1.SplunkForwarder
+	}{
+		// NOTE: These tests only make sense with useHeavy==true
+		// TODO: Permutations with useTag==useHFDigest==false should be invalid and produce a
+		// predictable error.
+		{
+			name:     "With digest",
+			instance: splunkForwarderInstance(true, false, false, true),
+		},
+		{
+			name:     "With HF digest; image digest is moot",
+			instance: splunkForwarderInstance(true, false, true, true),
+		},
+		{
+			name:     "Heavy Forwarder deployment with tag",
+			instance: splunkForwarderInstance(true, true, false, false),
+		},
+		{
+			name:     "Digest overrides tag",
+			instance: splunkForwarderInstance(true, true, false, true),
+		},
+		{
+			name:     "With HF tag; image digest is moot",
+			instance: splunkForwarderInstance(true, true, true, false),
+		},
+		{
+			name:     "HF digest overrides tag; image digest is moot",
+			instance: splunkForwarderInstance(true, true, true, true),
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := GenerateDeployment(tt.args.instance); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("GenerateDeployment() = %v, want %v", got, tt.want)
-			}
+			DeepEqualWithDiff(t,
+				expectedDeployment(tt.instance),
+				GenerateDeployment(tt.instance))
 		})
 	}
 }

--- a/pkg/kube/fixtures.go
+++ b/pkg/kube/fixtures.go
@@ -1,0 +1,64 @@
+package kube
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	sfv1alpha1 "github.com/openshift/splunk-forwarder-operator/pkg/apis/splunkforwarder/v1alpha1"
+)
+
+const (
+	instanceName      = "test"
+	instanceNamespace = "openshift-test"
+	image             = "test-image"
+	hfImage           = "test-hf-image"
+	imageTag          = "0.0.1"
+	imageDigest       = "sha256:2452a3f01e840661ee1194777ed5a9185ceaaa9ec7329ed364fa2f02be22a701"
+	heavyDigest       = "sha256:49b40c2c5d79913efb7eff9f3bf9c7348e322f619df10173e551b2596913d52a"
+)
+
+// splunkForwarderInstance returns (a pointer to) a SplunkForwarder CR as input to
+// GenerateDaemonSet. Parameters:
+// - useHeavy: The UseHeavyForwarder field is set to this value.
+// - useTag: If true, the ImageTag field is set.
+// - useDigest: If true, the ImageDigest field is set.
+// - useHFDigest: If true, the HeavyForwarderDigest field is set.
+func splunkForwarderInstance(useHeavy, useTag, useDigest, useHFDigest bool) *sfv1alpha1.SplunkForwarder {
+	spec := sfv1alpha1.SplunkForwarderSpec{
+		UseHeavyForwarder:      useHeavy,
+		HeavyForwarderReplicas: 0,
+		SplunkLicenseAccepted:  true,
+		HeavyForwarderSelector: "infra",
+		Image:                  image,
+		HeavyForwarderImage:    hfImage,
+	}
+	if useTag {
+		spec.ImageTag = imageTag
+	}
+	if useDigest {
+		spec.ImageDigest = imageDigest
+	}
+	if useHFDigest {
+		spec.HeavyForwarderDigest = heavyDigest
+	}
+	return &sfv1alpha1.SplunkForwarder{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       instanceName,
+			Namespace:  instanceNamespace,
+			Generation: 10,
+		},
+		Spec: spec,
+	}
+}
+
+// DoDiff deep-compares two `runtime.Object`s and fails the `t`est with a useful message (showing
+// the diff) if they differ.
+func DeepEqualWithDiff(t *testing.T, expected, actual runtime.Object) {
+	diff := cmp.Diff(expected, actual)
+	if diff != "" {
+		t.Fatal("Objects differ: -expected, +actual\n", diff)
+	}
+}

--- a/samples/splunkforwarder_v1alpha1_splunkforwarder_cr.yaml
+++ b/samples/splunkforwarder_v1alpha1_splunkforwarder_cr.yaml
@@ -4,7 +4,7 @@ metadata:
   name: example-splunkforwarder
 spec:
   image: quay.io/app-sre/splunk-forwarder
-  imageTag: 8.0.5-a1a6394cc5ae
+  imageDigest: sha256:2452a3f01e840661ee1194777ed5a9185ceaaa9ec7329ed364fa2f02be22a701
   splunkLicenseAccepted: true
   clusterID: mycluster
   splunkInputs:


### PR DESCRIPTION
Add two fields to the SplunkForwarder CRD: `imageDigest` and `heavyForwarderDigest`. If `imageDigest` is specified, the DaemonSet's container image pull spec is constructed as `{image}@{imageDigest}`. Similarly, if `heavyForwarderDigest` is specified, the Deployment's container image pull spec is constructed as `{heavyForwarderImage}@{heavyForwarderDigest}`. In either case, if `imageTag` is present it is ignored.

[OSD-7065](https://issues.redhat.com/browse/OSD-7065)