### PR TITLE
Revert "Hardcode by-digest URIs for splunk-[heavy]forwarder"

### DIFF
--- a/pkg/kube/daemonset.go
+++ b/pkg/kube/daemonset.go
@@ -76,8 +76,7 @@ func GenerateDaemonSet(instance *sfv1alpha1.SplunkForwarder) *appsv1.DaemonSet {
 						{
 							Name:            "splunk-uf",
 							ImagePullPolicy: corev1.PullAlways,
-							// TEMPORARY: hardcode by-digest pull spec
-							Image: "quay.io/app-sre/splunk-forwarder@sha256:2452a3f01e840661ee1194777ed5a9185ceaaa9ec7329ed364fa2f02be22a701",
+							Image:           instance.Spec.Image + ":" + instance.Spec.ImageTag,
 							Ports: []corev1.ContainerPort{
 								{
 									ContainerPort: 8089,

--- a/pkg/kube/daemonset_test.go
+++ b/pkg/kube/daemonset_test.go
@@ -105,7 +105,7 @@ func TestGenerateDaemonSet(t *testing.T) {
 								{
 									Name:            "splunk-uf",
 									ImagePullPolicy: corev1.PullAlways,
-									Image:           "quay.io/app-sre/splunk-forwarder@sha256:2452a3f01e840661ee1194777ed5a9185ceaaa9ec7329ed364fa2f02be22a701",
+									Image:           image + ":" + imageTag,
 									Ports: []corev1.ContainerPort{
 										{
 											ContainerPort: 8089,
@@ -182,7 +182,7 @@ func TestGenerateDaemonSet(t *testing.T) {
 								{
 									Name:            "splunk-uf",
 									ImagePullPolicy: corev1.PullAlways,
-									Image:           "quay.io/app-sre/splunk-forwarder@sha256:2452a3f01e840661ee1194777ed5a9185ceaaa9ec7329ed364fa2f02be22a701",
+									Image:           image + ":" + imageTag,
 									Ports: []corev1.ContainerPort{
 										{
 											ContainerPort: 8089,

--- a/pkg/kube/deployment.go
+++ b/pkg/kube/deployment.go
@@ -80,8 +80,7 @@ func GenerateDeployment(instance *sfv1alpha1.SplunkForwarder) *appsv1.Deployment
 						{
 							Name:            "splunk-hf",
 							ImagePullPolicy: corev1.PullAlways,
-							// TEMPORARY: hardcode by-digest pull spec
-							Image: "quay.io/app-sre/splunk-heavyforwarder@sha256:49b40c2c5d79913efb7eff9f3bf9c7348e322f619df10173e551b2596913d52a",
+							Image:           instance.Spec.HeavyForwarderImage + ":" + instance.Spec.ImageTag,
 							Ports: []corev1.ContainerPort{
 								{
 									ContainerPort: 8089,

--- a/pkg/kube/deployment_test.go
+++ b/pkg/kube/deployment_test.go
@@ -92,7 +92,7 @@ func TestGenerateDeployment(t *testing.T) {
 								{
 									Name:            "splunk-hf",
 									ImagePullPolicy: corev1.PullAlways,
-									Image:           "quay.io/app-sre/splunk-heavyforwarder@sha256:49b40c2c5d79913efb7eff9f3bf9c7348e322f619df10173e551b2596913d52a",
+									Image:           "test-image:0.0.1",
 									Ports: []corev1.ContainerPort{
 										{
 											ContainerPort: 8089,


### PR DESCRIPTION
Reverts openshift/splunk-forwarder-operator#101

It was temporary. We're going to do it right via #100.