### PR TITLE
Remove hack/app_sre_build_deploy.sh

### DIFF
--- a/hack/app_sre_build_deploy.sh
+++ b/hack/app_sre_build_deploy.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-
-# TODO: Replace the ci-ext command with `make build-push` and rip out
-# this script.
-make build-push


### PR DESCRIPTION
https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/18596 switched the app-sre ci-int job to invoke `make build-push` directly, so we don't need this wrapper script anymore.