### PR TITLE
Disable forwarding of splunk internal logs and metrics

### DIFF
--- a/containers/forwarder/Dockerfile
+++ b/containers/forwarder/Dockerfile
@@ -4,10 +4,10 @@ ADD containers/forwarder/bin/run.sh /
 ADD .splunk-version /
 ADD .splunk-version-hash /
 RUN export VERSION=$(cat /.splunk-version) && export VERSION_HASH=$(cat /.splunk-version-hash) && \
-    microdnf install -y libsemanage shadow-utils findutils procps wget && \
-    microdnf clean all && \
-    wget -O /tmp/splunkforwarder.rpm "https://www.splunk.com/bin/splunk/DownloadActivityServlet?architecture=x86_64&platform=linux&version=${VERSION}&product=universalforwarder&filename=splunkforwarder-${VERSION}-${VERSION_HASH}-linux-2.6-x86_64.rpm&wget=true" && \
+    curl -L -o /tmp/splunkforwarder.rpm "https://www.splunk.com/bin/splunk/DownloadActivityServlet?architecture=x86_64&platform=linux&version=${VERSION}&product=universalforwarder&filename=splunkforwarder-${VERSION}-${VERSION_HASH}-linux-2.6-x86_64.rpm&wget=true" && \
+    microdnf -y install findutils libsemanage procps-ng shadow-utils && \
     rpm -ivh /tmp/splunkforwarder.rpm && \
+    microdnf clean all && \
     rm -f /tmp/splunkforwarder.rpm && \
     mkdir -p /host && chown splunk:splunk /host && \
     mkdir -p /opt/splunkforwarder/var/{lib,run,spool}/splunk && \

--- a/containers/forwarder/bin/run.sh
+++ b/containers/forwarder/bin/run.sh
@@ -8,11 +8,27 @@ if [[ ${SPLUNK_ACCEPT_LICENSE} == "yes" ]]; then
     SPLUNK_ARGS="${SPLUNK_ARGS} --accept-license"
 fi
 
+cat >>etc/system/local/inputs.conf <<-EOF
+    # disable forwarding splunk-internal logs
+    [monitor://\$SPLUNK_HOME/var/log/splunk]
+    disabled = true
+    [monitor://\$SPLUNK_HOME/var/log/splunk/splunkd.log]
+    disabled = true
+    [monitor://\$SPLUNK_HOME/var/log/splunk/metrics.log]
+    disabled = true
+    [monitor://\$SPLUNK_HOME/var/log/introspection]
+    disabled = true
+    [monitor://\$SPLUNK_HOME/var/log/splunk/splunk_instrumentation_cloud.log*]
+    disabled = true
+    [batch://\$SPLUNK_HOME/var/run/splunk/search_telemetry/*search_telemetry.json]
+    disabled = true
+EOF
+
 ./bin/splunk start ${SPLUNK_ARGS}
 
-# The above command still forks to the background even with --nodaemon so 
+# The above command still forks to the background even with --nodaemon so
 # we do the tried and true while true sleep
-SPLINK_PID_FILE="/opt/splunkforwarder/var/run/splunk/splunkd.pid"
+SPLUNK_PID_FILE="/opt/splunkforwarder/var/run/splunk/splunkd.pid"
 while true; do
     if [[ ! -f $SPLUNK_PID_FILE ]]; then
         exit 1

--- a/containers/heavy_forwarder/Dockerfile
+++ b/containers/heavy_forwarder/Dockerfile
@@ -4,10 +4,10 @@ ADD containers/heavy_forwarder/bin/run.sh /
 ADD .splunk-version /
 ADD .splunk-version-hash /
 RUN export VERSION=$(cat /.splunk-version) && export VERSION_HASH=$(cat /.splunk-version-hash) && \
-    microdnf install -y libsemanage shadow-utils findutils procps wget && \
-    microdnf clean all && \
-    wget -O /tmp/splunk.rpm "https://www.splunk.com/bin/splunk/DownloadActivityServlet?architecture=x86_64&platform=linux&version=${VERSION}&product=splunk&filename=splunk-${VERSION}-${VERSION_HASH}-linux-2.6-x86_64.rpm&wget=true" && \
+    curl -Lo /tmp/splunk.rpm "https://www.splunk.com/bin/splunk/DownloadActivityServlet?architecture=x86_64&platform=linux&version=${VERSION}&product=splunk&filename=splunk-${VERSION}-${VERSION_HASH}-linux-2.6-x86_64.rpm&wget=true" && \
+    microdnf install -y findutils libsemanage procps-ng shadow-utils && \
     rpm -ivh /tmp/splunk.rpm && \
+    microdnf clean all && \
     rm -f /tmp/splunk.rpm && \
     mkdir -p /host && chown splunk:splunk /host && \
     mkdir -p /opt/splunk/var/{lib,run,spool}/splunk && \

--- a/containers/heavy_forwarder/bin/run.sh
+++ b/containers/heavy_forwarder/bin/run.sh
@@ -8,12 +8,28 @@ if [[ ${SPLUNK_ACCEPT_LICENSE} == "yes" ]]; then
     SPLUNK_ARGS="${SPLUNK_ARGS} --accept-license"
 fi
 
+cat >>etc/system/local/inputs.conf <<-EOF
+    # disable forwarding splunk-internal logs
+    [monitor://\$SPLUNK_HOME/var/log/splunk]
+    disabled = true
+    [monitor://\$SPLUNK_HOME/var/log/splunk/splunkd.log]
+    disabled = true
+    [monitor://\$SPLUNK_HOME/var/log/splunk/metrics.log]
+    disabled = true
+    [monitor://\$SPLUNK_HOME/var/log/introspection]
+    disabled = true
+    [monitor://\$SPLUNK_HOME/var/log/splunk/splunk_instrumentation_cloud.log*]
+    disabled = true
+    [batch://\$SPLUNK_HOME/var/run/splunk/search_telemetry/*search_telemetry.json]
+    disabled = true
+EOF
+
 # Switch to forwarder license
 ./bin/splunk edit licenser-groups Forwarder -is_active 1 ${SPLUNK_ARGS}
 
 ./bin/splunk start --nodaemon
 
-# The above command still forks to the background even with --nodaemon so 
+# The above command still forks to the background even with --nodaemon so
 # we do the tried and true while true sleep
 SPLUNK_PID_FILE="/opt/splunk/var/run/splunk/splunkd.pid"
 while true; do


### PR DESCRIPTION
Disables forwarding of splunk-internal logs, **except** for:
* `$SPLUNK_HOME/var/log/watchdog/watchdog.log`
* `$SPLUNK_HOME/etc/splunk.version`
* `$SPLUNK_HOME/var/log/splunk/license_usage_summary.log`

Also/minor change:
* fix typo in `containers/forwarder/bin/run.sh`
