### PR TITLE
Use IMAGE_DIGEST in OLM template

### DIFF
--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -8,9 +8,7 @@ parameters:
   required: true
 - name: CHANNEL
   value: staging
-- name: IMAGE_TAG
-  value: latest
-- name: REPO_DIGEST
+- name: IMAGE_DIGEST
   required: true
 - name: ALERTS_SKIP_LEGALENTITY_IDS
   value: '["none"]'
@@ -147,7 +145,7 @@ objects:
         namespace: openshift-splunk-forwarder-operator
       spec:
         sourceType: grpc
-        image: ${REPO_DIGEST}
+        image: ${REGISTRY_IMG}@${IMAGE_DIGEST}
         displayName: splunk-forwarder-operator Registry
         publisher: SRE
         affinity:


### PR DESCRIPTION
To make the OLM template easier to understand, replace `${REPO_DIGEST}` with `${REGISTRY_IMG}@${IMAGE_DIGEST}`.

`IMAGE_DIGEST` is supported as of APPSRE-3265.