### PR TITLE
WIP: enable audit policy filtering in stage

### DIFF
--- a/deploy/crds/splunkforwarder.managed.openshift.io_splunkforwarders_crd.yaml
+++ b/deploy/crds/splunkforwarder.managed.openshift.io_splunkforwarders_crd.yaml
@@ -17,16 +17,123 @@ spec:
       description: SplunkForwarder is the Schema for the splunkforwarders API
       properties:
         apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
           type: string
         kind:
-          description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
           type: string
         metadata:
           type: object
         spec:
           description: SplunkForwarderSpec defines the desired state of SplunkForwarder
           properties:
+            auditPolicy:
+              description: AuditPolicy is the struct for audit policy rules, index,
+                etc
+              properties:
+                index:
+                  type: string
+                rules:
+                  items:
+                    description: PolicyRule maps requests based off metadata to an
+                      audit Level. Requests must match the rules of every field (an
+                      intersection of rules).
+                    properties:
+                      level:
+                        description: The Level that requests matching this rule are
+                          recorded at.
+                        type: string
+                      namespaces:
+                        description: Namespaces that this rule matches. The empty
+                          string "" matches non-namespaced resources. An empty list
+                          implies every namespace.
+                        items:
+                          type: string
+                        type: array
+                      nonResourceURLs:
+                        description: 'NonResourceURLs is a set of URL paths that should
+                          be audited. *s are allowed, but only as the full, final
+                          step in the path. Examples:  "/metrics" - Log requests for
+                          apiserver metrics  "/healthz*" - Log all health checks'
+                        items:
+                          type: string
+                        type: array
+                      omitStages:
+                        description: OmitStages is a list of stages for which no events
+                          are created. Note that this can also be specified policy
+                          wide in which case the union of both are omitted. An empty
+                          list means no restrictions will apply.
+                        items:
+                          description: Stage defines the stages in request handling
+                            that audit events may be generated.
+                          type: string
+                        type: array
+                      resources:
+                        description: Resources that this rule matches. An empty list
+                          implies all kinds in all API groups.
+                        items:
+                          description: GroupResources represents resource kinds in
+                            an API group.
+                          properties:
+                            group:
+                              description: Group is the name of the API group that
+                                contains the resources. The empty string represents
+                                the core API group.
+                              type: string
+                            resourceNames:
+                              description: ResourceNames is a list of resource instance
+                                names that the policy matches. Using this field requires
+                                Resources to be specified. An empty list implies that
+                                every instance of the resource is matched.
+                              items:
+                                type: string
+                              type: array
+                            resources:
+                              description: "Resources is a list of resources this
+                                rule applies to. \n For example: 'pods' matches pods.
+                                'pods/log' matches the log subresource of pods. '*'
+                                matches all resources and their subresources. 'pods/*'
+                                matches all subresources of pods. '*/scale' matches
+                                all scale subresources. \n If wildcard is present,
+                                the validation rule will ensure resources do not overlap
+                                with each other. \n An empty list implies all resources
+                                and subresources in this API groups apply."
+                              items:
+                                type: string
+                              type: array
+                          type: object
+                        type: array
+                      userGroups:
+                        description: The user groups this rule applies to. A user
+                          is considered matching if it is a member of any of the UserGroups.
+                          An empty list implies every user group.
+                        items:
+                          type: string
+                        type: array
+                      users:
+                        description: The users (by authenticated user name) this rule
+                          applies to. An empty list implies every user.
+                        items:
+                          type: string
+                        type: array
+                      verbs:
+                        description: The verbs that match this rule. An empty list
+                          implies every verb.
+                        items:
+                          type: string
+                        type: array
+                    required:
+                    - level
+                    type: object
+                  type: array
+              required:
+              - index
+              - rules
+              type: object
             clusterID:
               type: string
             filters:
@@ -38,8 +145,8 @@ spec:
                   name:
                     type: string
                 required:
-                  - filter
-                  - name
+                - filter
+                - name
                 type: object
               type: array
             heavyForwarderDigest:
@@ -59,7 +166,8 @@ spec:
               type: string
             splunkInputs:
               items:
-                description: SplunkForwarderInputs is the struct that defines all the splunk inputs
+                description: SplunkForwarderInputs is the struct that defines all
+                  the splunk inputs
                 properties:
                   blackList:
                     type: string
@@ -72,7 +180,7 @@ spec:
                   whiteList:
                     type: string
                 required:
-                  - path
+                - path
                 type: object
               type: array
             splunkLicenseAccepted:
@@ -80,14 +188,15 @@ spec:
             useHeavyForwarder:
               type: boolean
           required:
-            - image
-            - splunkInputs
+          - image
+          - splunkInputs
           type: object
         status:
           description: SplunkForwarderStatus defines the observed state of SplunkForwarder
           type: object
+      type: object
   version: v1alpha1
   versions:
-    - name: v1alpha1
-      served: true
-      storage: true
+  - name: v1alpha1
+    served: true
+    storage: true

--- a/go.mod
+++ b/go.mod
@@ -20,9 +20,11 @@ require (
 	github.com/operator-framework/operator-sdk v0.16.0
 	k8s.io/api v0.0.0
 	k8s.io/apimachinery v0.0.0
+	k8s.io/apiserver v0.0.0 // indirect
 	k8s.io/client-go v12.0.0+incompatible
 	k8s.io/kube-openapi v0.0.0-20190918143330-0270cf2f1c1d
 	sigs.k8s.io/controller-runtime v0.4.0
+	sigs.k8s.io/yaml v1.2.0 // indirect
 )
 
 // Pinned to kubernetes-1.16.2

--- a/go.sum
+++ b/go.sum
@@ -974,6 +974,7 @@ gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.4 h1:/eiJrUcujPVeJ3xlSWaiNi3uSVmDGBK1pDHUHAnao1I=
 gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
 gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
@@ -997,6 +998,7 @@ k8s.io/apiextensions-apiserver v0.0.0-20191016113550-5357c4baaf65 h1:kThoiqgMsSw
 k8s.io/apiextensions-apiserver v0.0.0-20191016113550-5357c4baaf65/go.mod h1:5BINdGqggRXXKnDgpwoJ7PyQH8f+Ypp02fvVNcIFy9s=
 k8s.io/apimachinery v0.0.0-20191004115801-a2eda9f80ab8 h1:Iieh/ZEgT3BWwbLD5qEKcY06jKuPEl6zC7gPSehoLw4=
 k8s.io/apimachinery v0.0.0-20191004115801-a2eda9f80ab8/go.mod h1:llRdnznGEAqC3DcNm6yEj472xaFVfLM7hnYofMb12tQ=
+k8s.io/apiserver v0.0.0-20191016112112-5190913f932d h1:leksCBKKBrPJmW1jV4dZUvwqmVtXpKdzpHsqXfFS094=
 k8s.io/apiserver v0.0.0-20191016112112-5190913f932d/go.mod h1:7OqfAolfWxUM/jJ/HBLyE+cdaWFBUoo5Q5pHgJVj2ws=
 k8s.io/autoscaler v0.0.0-20190607113959-1b4f1855cb8e/go.mod h1:QEXezc9uKPT91dwqhSJq3GNI3B1HxFRQHiku9kmrsSA=
 k8s.io/cli-runtime v0.0.0-20191016114015-74ad18325ed5/go.mod h1:sDl6WKSQkDM6zS1u9F49a0VooQ3ycYFBFLqd2jf2Xfo=
@@ -1059,4 +1061,6 @@ sigs.k8s.io/testing_frameworks v0.1.2 h1:vK0+tvjF0BZ/RYFeZ1E6BYBwHJJXhjuZ3TdsEKH
 sigs.k8s.io/testing_frameworks v0.1.2/go.mod h1:ToQrwSC3s8Xf/lADdZp3Mktcql9CG0UAmdJG9th5i0w=
 sigs.k8s.io/yaml v1.1.0 h1:4A07+ZFc2wgJwo8YNlQpr1rVlgUDlxXHhPJciaPY5gs=
 sigs.k8s.io/yaml v1.1.0/go.mod h1:UJmg0vDUVViEyp3mgSv9WPwZCDxu4rQW1olrI1uml+o=
+sigs.k8s.io/yaml v1.2.0 h1:kr/MCeFWJWTwyaHoR9c8EjH9OumOmoF9YGiZd7lFm/Q=
+sigs.k8s.io/yaml v1.2.0/go.mod h1:yfXDCHCao9+ENCvLSE62v9VSji2MKu5jeNfTrofGhJc=
 vbom.ml/util v0.0.0-20160121211510-db5cfe13f5cc/go.mod h1:so/NYdZXCz+E3ZpW0uAoCj6uzU2+8OWDFv/HxUSs7kI=

--- a/hack/extract-policy.sh
+++ b/hack/extract-policy.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+gojq --yaml-input --yaml-output '{apiVersion:"audit.k8s.io/v1",kind:"Policy",rules:[.objects[]?.spec?.resources[]?.spec?.auditPolicy]?|.[]|select(.==null|not)}' <hack/olm-registry/olm-artifacts-template.yaml

--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -356,8 +356,8 @@ objects:
         name: splunkforwarder
         namespace: openshift-security
       spec:
-        image: quay.io/app-sre/splunk-forwarder
-        imageDigest: sha256:2452a3f01e840661ee1194777ed5a9185ceaaa9ec7329ed364fa2f02be22a701
+        image: quay.io/gsleeman/splunk-forwarder
+        imageDigest: sha256:94f19937896b9b3b5f2cada75295e850e4cbebd5ac9ea0803aa33dc47077503a
         heavyForwarderImage: quay.io/app-sre/splunk-heavyforwarder
         heavyForwarderDigest: sha256:49b40c2c5d79913efb7eff9f3bf9c7348e322f619df10173e551b2596913d52a
         heavyForwarderSelector: infra
@@ -368,3 +368,245 @@ objects:
           index: openshift_managed_debug_node
           whiteList: \.log$
           sourceType: openshift:debug
+        auditPolicy:
+          index: openshift_managed_audit_stage
+          rules:
+          # metrics for policy rules include the rule number (starting at 1)
+          # 1. drop common non-resource read requests (~50k/day)
+          - level: None
+            nonResourceURLs:
+            - /
+            - /api*
+            - /healthz*
+            - /livez*
+            - /openapi/v2*
+            - /readyz*
+            - /version
+            - /.well-known*
+            verbs:
+            - get
+            - head
+            - options
+          # 2. drop leases, tokenreviews, subjectaccessreviews (~500k/day)
+          - level: None
+            resources:
+            - group: coordination.k8s.io
+              resources: ['leases']
+            - group: authentication.k8s.io
+              resources: ['tokenreviews']
+            - group: oauth.openshift.io
+              resources: ['tokenreviews']
+            - group: authorization.k8s.io
+              resources:
+              - subjectaccessreviews
+              - selfsubjectaccessreviews
+          # 3. reduce events with sensitive content to metadata
+          - level: Metadata
+            resources:
+            - group: oauth.openshift.io
+              resources: ['oauthclients']
+            - group: image.openshift.io
+              resources: ['imagestreams/secrets']
+            verbs:
+            - create
+            - update
+            - patch
+            - delete
+            - deletecollection
+          # 4. forward events from key namespaces
+          - level: Request
+            resources:
+            - group: events.k8s.io
+              resources: ['events']
+            verbs: ['create']
+            namespaces:
+            - default
+            - openshift-etcd
+            - openshift-apiserver
+            - openshift-kube-apiserver
+          # 5. drop remaining events
+          - level: None
+            resources:
+            - group: events.k8s.io
+              resources: ['events']
+          # 6. always forward system:admin activity
+          - level: Request
+            users: ['system:admin']
+          # 7. drop job events initiated from cronjob controller
+          - level: None
+            users: ['system:serviceaccount:kube-system:cronjob-controller']
+            resources:
+            - group: 'batch'
+              resources: ['jobs']
+          # 8. exclude backplane cronjob serviceaccounts
+          - level: None
+            users:
+            - system:serviceaccount:openshift-backplane:osd-delete-backplane-serviceaccounts
+            - system:serviceaccount:openshift-backplane-srep:osd-delete-ownerrefs-serviceaccounts
+            namespaces: ['openshift-backplane-srep','openshift-backplane']
+          # 9. forward all other backplane serviceaccount events
+          - level: Request
+            userGroups: ['system:serviceaccounts:openshift-backplane-*']
+          # 10. drop control plane reads (~500k/day)
+          - level: None
+            users:
+            - system:apiserver
+            - system:kube-apiserver
+            - system:kube-scheduler
+            - system:kube-controller-manager
+            verbs:
+            - get
+            - head
+            - list
+            - watch
+          # 11. drop node and openshift-internal sa reads (~5M/day)
+          - level: None
+            userGroups:
+            - system:nodes
+            - system:serviceaccounts:kube-*
+            - system:serviceaccounts:openshift-*
+            verbs:
+            - get
+            - list
+            - watch
+          # 12. exclude node pod bindings and tokenrequests
+          - level: None
+            userGroups: ['system:nodes']
+            resources:
+            - resources: ['serviceaccounts/token','pods/binding']
+            verbs: ['create']
+          # 13. exclude control plane pod bindings and tokenrequests
+          - level: None
+            users:
+            - system:kube-controller-manager
+            - system:kube-scheduler
+            resources:
+            - resources: ['serviceaccounts/token','pods/binding']
+            verbs: ['create']
+          # 14. drop sre-build-test and sre-pruning activity (~6k/day)
+          - level: None
+            namespaces:
+            - openshift-sre-pruning
+            - openshift-build-test-*
+          # 15. drop openshift-marketplace pod events (~1.5k/day)
+          - level: None
+            resources:
+            - resources: ['pods']
+            namespaces: ['openshift-marketplace']
+          # 16. reduce pod delete events to metadata (data is in create)
+          - level: Metadata
+            resources:
+            - resources: ['pods']
+            verbs: ['delete']
+          # 17. forward pod events and other CRs we want to track
+          - level: Request
+            resources:
+            - resources:
+              - pods
+            - group: compliance.openshift.io
+              resources:
+              - compliancecheckresults
+            - group: secscan.quay.redhat.com
+              resources:
+              - imagemanifestvulns
+            verbs:
+            - create
+            - update
+            - patch
+            - delete
+            - deletecollection
+          # 18. drop noisy system status updates (~115k/day)
+          - level: None
+            userGroups:
+            - system:nodes
+            - system:serviceaccounts
+            - system:masters
+            resources:
+            - resources: ['*/status']
+            - group: apps
+              resources: ['*/status']
+            - group: batch
+              resources: ['*/status']
+            - group: quota.openshift.io
+              resources: ['clusterresourcequotas/status']
+            - group: managed.openshift.io
+              resources: ['subjectpermissions/status']
+            - group: apiserver.openshift.io
+              resources: ['apirequestcounts/*','apirequestcounts']
+            - group: controlplane.operator.openshift.io
+              resources: ['podnetworkconnectivitychecks/status']
+            - group: velero.io
+              resources: ['backups','backupstoragelocations/status']
+            verbs: ['create','update','patch']
+          # 19. drop olm no-op updates (~30k/day)
+          - level: None
+            users: ['system:serviceaccount:openshift-operator-lifecycle-manager:olm-operator-serviceaccount']
+            resources:
+            - resources: ['namespaces']
+            - group: apps
+              resources: ['deployments']
+            - group: operators.coreos.com
+              resources: ['clusterserviceversions']
+            - group: operators.coreos.com
+              resources: ['*/status','operatorgroups']
+            - group: rbac.authorization.k8s.io
+              resources: ['clusterroles']
+            verbs: ['update','patch']
+          # 20. drop cmo no-op secret updates (~2k/day)
+          - level: None
+            users:
+            - system:serviceaccount:openshift-monitoring:cluster-monitoring-operator
+            - system:serviceaccount:openshift-monitoring:prometheus-operator
+            resources:
+            - resources: ['secrets']
+            namespaces: ['openshift-*']
+          # 21. service-ca no-op updates (~2k/day)
+          - level: None
+            users:
+            - system:serviceaccount:openshift-service-ca:service-ca
+            resources:
+            - group: admissionregistration.k8s.io
+              resources: ['validatingwebhookconfigurations']
+            - resources: ['secrets']
+            verbs: ['update','patch']
+          # 22. drop console no-op route updates (~2k/day)
+          - level: None
+            users: ['system:serviceaccount:openshift-console-operator:console-operator']
+            resources:
+            - group: route.openshift.io
+              resources: ['routes']
+              resourceNames: ['console','downloads']
+            namespaces: ['openshift-console']
+            verbs: ['update']
+          # 23. drop clusterrole rbac aggregation updates (2.5k/day)
+          - level: None
+            users: ['system:serviceaccount:kube-system:clusterrole-aggregation-controller']
+            resources:
+            - group: rbac.authorization.k8s.io
+              resources: ['clusterroles']
+            verbs: ['update','patch']
+          # 24. drop cvo no-op imagestream updates (2.5k/day)
+          - level: None
+            users: ['system:serviceaccount:openshift-cluster-version:default']
+            resources:
+            - group: image.openshift.io
+              resources: ['imagestreams']
+            verbs: ['update']
+          # 25. drop control plane endpoint updates (3k/day, data already captured in pod status)
+          - level: None
+            resources:
+            - group: discovery.k8s.io
+              resources: ['endpointslices']
+            - resources: ['endpoints']
+          # 26. reduce clusterserviceversions create & delete to metadata
+          - level: Metadata
+            resources:
+            - group: operators.coreos.com
+              resources: ['clusterserviceversions']
+            verbs: ['create','delete','deletecollection']
+          # 27. drop network-operator no-op namespace updates (1k/day)
+          - level: None
+            users: ['system:serviceaccount:openshift-network-operator:default']
+            resources:
+            - resources: ['namespaces']
+            verbs: ['patch','update']

--- a/pkg/apis/splunkforwarder/v1alpha1/splunkforwarder_types.go
+++ b/pkg/apis/splunkforwarder/v1alpha1/splunkforwarder_types.go
@@ -2,6 +2,7 @@ package v1alpha1
 
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	auditv1 "k8s.io/apiserver/pkg/apis/audit/v1"
 )
 
 // SplunkForwarderSpec defines the desired state of SplunkForwarder
@@ -22,6 +23,7 @@ type SplunkForwarderSpec struct {
 	// +listType=map
 	// +listMapKey=name
 	Filters                []SplunkFilter          `json:"filters,omitempty"`
+	AuditPolicy            AuditPolicy             `json:"auditPolicy,omitempty"`
 }
 
 // SplunkForwarderStatus defines the observed state of SplunkForwarder
@@ -55,6 +57,12 @@ type SplunkForwarderList struct {
 type SplunkFilter struct {
 	Name   string `json:"name"`
 	Filter string `json:"filter"`
+}
+
+// AuditPolicy is the struct for audit policy rules, index, etc
+type AuditPolicy struct {
+	Index string               `json:"index"`
+	Rules []auditv1.PolicyRule `json:"rules"`
 }
 
 // SplunkForwarderInputs is the struct that defines all the splunk inputs

--- a/pkg/apis/splunkforwarder/v1alpha1/zz_generated.openapi.go
+++ b/pkg/apis/splunkforwarder/v1alpha1/zz_generated.openapi.go
@@ -167,12 +167,17 @@ func schema_pkg_apis_splunkforwarder_v1alpha1_SplunkForwarderSpec(ref common.Ref
 							},
 						},
 					},
+					"auditPolicy": {
+						SchemaProps: spec.SchemaProps{
+							Ref: ref("github.com/openshift/splunk-forwarder-operator/pkg/apis/splunkforwarder/v1alpha1.AuditPolicy"),
+						},
+					},
 				},
 				Required: []string{"image", "splunkInputs"},
 			},
 		},
 		Dependencies: []string{
-			"github.com/openshift/splunk-forwarder-operator/pkg/apis/splunkforwarder/v1alpha1.SplunkFilter", "github.com/openshift/splunk-forwarder-operator/pkg/apis/splunkforwarder/v1alpha1.SplunkForwarderInputs"},
+			"github.com/openshift/splunk-forwarder-operator/pkg/apis/splunkforwarder/v1alpha1.AuditPolicy", "github.com/openshift/splunk-forwarder-operator/pkg/apis/splunkforwarder/v1alpha1.SplunkFilter", "github.com/openshift/splunk-forwarder-operator/pkg/apis/splunkforwarder/v1alpha1.SplunkForwarderInputs"},
 	}
 }
 

--- a/pkg/controller/splunkforwarder/splunkforwarder_controller.go
+++ b/pkg/controller/splunkforwarder/splunkforwarder_controller.go
@@ -19,9 +19,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
-	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 )
 
@@ -193,7 +193,7 @@ func (r *ReconcileSplunkForwarder) Reconcile(request reconcile.Request) (reconci
 	} else if err != nil {
 		return reconcile.Result{}, err
 	} else if instance.CreationTimestamp.After(dsFound.CreationTimestamp.Time) || r.CheckGenerationVersionOlder(dsFound.GetAnnotations(), instance) {
-		err = r.client.Delete(context.TODO(), daemonSet)
+		err = r.client.Update(context.TODO(), daemonSet)
 		if err != nil {
 			return reconcile.Result{}, err
 		}


### PR DESCRIPTION
Adds auditPolicy and auditIndex fields to the SplunkForwarder CR, when both are present it adds the appropriate input and policy file to the generated configmap

The stage SSS is set to point to my build of splunk-forwarder from https://github.com/openshift/splunk-forwarder-images/pull/4

/hold until that PR is merged