### PR TITLE
adding file integrity operator logs to inputs

### DIFF
--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -334,6 +334,12 @@ objects:
           index: openshift_managed_backplane_prod
           sourceType: _json
           whiteList: \.log$
+        - path: /host/etc/kubernetes/aide.log
+          index: openshift_managed_fio_results
+          sourceType: log
+        - path: /host/etc/kubernetes/aide.log.new
+          index: openshift_managed_fio_results
+          sourceType: log     
 
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet


### PR DESCRIPTION
- addresses [OSD-5964](https://issues.redhat.com/browse/OSD-5964)
- adds file integrity operator specific logs to splunkforwarder object in sss