### PR TITLE
Target only fedramp clusters for heavyforwarder

### DIFF
--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -344,10 +344,7 @@ objects:
     clusterDeploymentSelector:
       matchExpressions:
         - { key: api.openshift.com/managed, operator: In, values: ["true"] }
-        - { key: api.openshift.com/environment, operator: In, values: ["staging"] }
-        - { key: api.openshift.com/noalerts, operator: NotIn, values: ["true"] }
-        - { key: ext-managed.openshift.io/noalerts, operator: NotIn, values: ["true"] }
-        - { key: hive.openshift.io/cluster-region, operator: NotIn, values: ["cn-north-1", "cn-northwest-1"] }
+        - { key: api.openshift.com/fedramp, operator: In, values: ["true"] }
     resourceApplyMode: Sync
     resources:
     - apiVersion: splunkforwarder.managed.openshift.io/v1alpha1


### PR DESCRIPTION
This allows the SelectorSyncSet to get deployed to all FedRAMP envs.