### PR TITLE
Ensure events aren't truncated in light-forwarder-only mode

### DIFF
--- a/pkg/kube/configmaps.go
+++ b/pkg/kube/configmaps.go
@@ -1,6 +1,7 @@
 package kube
 
 import (
+	"fmt"
 	"strconv"
 
 	sfv1alpha1 "github.com/openshift/splunk-forwarder-operator/pkg/apis/splunkforwarder/v1alpha1"
@@ -95,10 +96,10 @@ is_visible = false
 is_manageable = false
 `,
 			"inputs.conf": inputsStr,
-			"props.conf": `
+			"props.conf": fmt.Sprintf(`
 [_json]
-TRUNCATE = 1000000
-`,
+TRUNCATE = %d
+`, MaxEventSize),
 		},
 	}
 
@@ -137,10 +138,10 @@ server = ` + instance.Name + `:9997
 [thruput]
 maxKBps = 0
 `,
-			"props.conf": `
+			"props.conf": fmt.Sprintf(`
 [_json]
-TRUNCATE = 1000000
-`,
+TRUNCATE = %d
+`, MaxEventSize),
 		},
 	}
 
@@ -168,10 +169,10 @@ connection_host = dns
 maxKBps = 0
 `
 
-	data["props.conf"] = `
+	data["props.conf"] = fmt.Sprintf(`
 [_json]
-TRUNCATE = 1000000
-`
+TRUNCATE = %d
+`, MaxEventSize)
 
 	if len(instance.Spec.Filters) > 0 {
 		data["transforms.conf"] = ""

--- a/pkg/kube/configmaps.go
+++ b/pkg/kube/configmaps.go
@@ -95,6 +95,10 @@ is_visible = false
 is_manageable = false
 `,
 			"inputs.conf": inputsStr,
+			"props.conf": `
+[_json]
+TRUNCATE = 1000000
+`,
 		},
 	}
 

--- a/pkg/kube/configmaps_test.go
+++ b/pkg/kube/configmaps_test.go
@@ -117,6 +117,10 @@ _meta = clusterid::test
 disabled = false
 
 `,
+					"props.conf": `
+[_json]
+TRUNCATE = 1000000
+`,
 					},
 				},
 			},

--- a/pkg/kube/configmaps_test.go
+++ b/pkg/kube/configmaps_test.go
@@ -1,6 +1,7 @@
 package kube
 
 import (
+	"fmt"
 	"reflect"
 	"testing"
 
@@ -117,10 +118,10 @@ _meta = clusterid::test
 disabled = false
 
 `,
-					"props.conf": `
+					"props.conf": fmt.Sprintf(`
 [_json]
-TRUNCATE = 1000000
-`,
+TRUNCATE = %d
+`, MaxEventSize),
 					},
 				},
 			},
@@ -187,10 +188,10 @@ server = test:9997
 [thruput]
 maxKBps = 0
 `,
-					"props.conf": `
+					"props.conf": fmt.Sprintf(`
 [_json]
-TRUNCATE = 1000000
-`,
+TRUNCATE = %d
+`, MaxEventSize),
 				},
 			},
 		},
@@ -271,10 +272,10 @@ connection_host = dns
 [thruput]
 maxKBps = 0
 `,
-					"props.conf": `
+					"props.conf": fmt.Sprintf(`
 [_json]
-TRUNCATE = 1000000
-`,
+TRUNCATE = %d
+`, MaxEventSize),
 				},
 			},
 		},
@@ -312,10 +313,10 @@ connection_host = dns
 [thruput]
 maxKBps = 0
 `,
-					"props.conf": `
+					"props.conf": fmt.Sprintf(`
 [_json]
-TRUNCATE = 1000000
-TRANSFORMS-null =filter_ignore_chatty_system_users `,
+TRUNCATE = %d
+TRANSFORMS-null =filter_ignore_chatty_system_users `, MaxEventSize),
 					"transforms.conf": `[filter_ignore_chatty_system_users]
 DEST_KEY = queue
 FORMAT = nullQueue

--- a/pkg/kube/constants.go
+++ b/pkg/kube/constants.go
@@ -1,0 +1,5 @@
+package kube
+
+const (
+    MaxEventSize = 100 * 1024 // 100KB per k8s.io/kubernetes/apiserver/pkg/server/options/audit.go
+)


### PR DESCRIPTION
Sets the TRUNCATE value to the maximum expected audit event length.

(This was already applied when operating in heavy-forwarder mode, expanded to apply also to light-forwarder-only mode)