### PR TITLE
[OSD-10390] - Adding support for FIO logs

### DIFF
--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -694,6 +694,17 @@ objects:
             - create
             - update
             - patch
+          - level: Request
+            users:
+            - system:serviceaccount:openshift-file-integrity:file-integrity-daemon
+            resources:
+            - group: fileintegrity.openshift.io
+              resources: ['configmaps']
+            namespaces: ["openshift-file-integrity"]
+            verbs:
+            - create
+            - update
+            - patch
           # drop resource status updates (~100k/day)
           - level: None
             resources:

--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -698,8 +698,7 @@ objects:
             users:
             - system:serviceaccount:openshift-file-integrity:file-integrity-daemon
             resources:
-            - group: fileintegrity.openshift.io
-              resources: ['configmaps']
+            - resources: ['configmaps']
             namespaces: ["openshift-file-integrity"]
             verbs:
             - create


### PR DESCRIPTION
This change will add support to forward File Integrity Operator logs to splunk.  The change has been tested and verified to provide the desired outcome