### PR TITLE
[OSD-10974] - change suricata log file

### DIFF
--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -462,8 +462,8 @@ objects:
           sourceType: linux_audit
           whiteList: \.log$
         - index: rh_osd_suricata
-          path: /host/var/log/fast.log
-          sourceType: syslog
+          path: /host/var/log/eve-*.json
+          sourceType: _json
           whiteList: \.log$
         - index: rh_osd_fail2ban
           path: /host/var/log/fail2ban.log


### PR DESCRIPTION
We are changing the monitored log file from fast.log to a date rotated eve json log file.  This log has been reduced to a manageable size.