### PR TITLE
Address gosec warning [OSD-11470]

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -4,5 +4,5 @@ const (
 	OperatorName      string = "splunk-forwarder-operator"
 	OperatorNamespace string = "splunk-forwarder-operator"
 
-	SplunkAuthSecretName string = "splunk-auth"
+	SplunkAuthSecretName string = "splunk-auth" // #nosec G101 -- This is a false positive
 )


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/OSD-11470, addressing gosec warning