### PR TITLE
change openshift-scanning logging method

### DIFF
--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -339,14 +339,14 @@ objects:
           index: openshift_managed_debug_node
           whiteList: \.log$
           sourceType: openshift:debug
-        - path: /host/var/log/openshift_managed_pod_creation.log
+        - path: /host/var/log/pods/openshift-scanning_logger-*/pod-printer/*.log
           index: openshift_managed_pod_creation
           whiteList: \.log$
-          sourceType: _json
-        - path: /host/var/log/openshift_managed_malware_scan.log
+          sourceType: openshift:debug
+        - path: /host/var/log/pods/openshift-scanning_logger-*/scan-printer/*.log
           index: openshift_managed_malware_scan
           whiteList: \.log$
-          sourceType: _json
+          sourceType: openshift:debug
         - path: /host/var/lib/kubelet/pods/*/volumes/kubernetes.io~*/pvc-*/backplane-audit.log
           index: openshift_managed_backplane_prod
           sourceType: _json
@@ -448,12 +448,12 @@ objects:
           sourceType: _json
           whiteList: \.log$
         - index: rh_osd_pod_creation
-          path: /host/var/log/openshift_managed_pod_creation.log
-          sourceType: _json
+          path: /host/var/log/pods/openshift-scanning_logger-*/pod-printer/*.log
+          sourceType: openshift:debug
           whiteList: \.log$
         - index: rh_osd_malware_scan
-          path: /host/var/log/openshift_managed_malware_scan.log
-          sourceType: _json
+          path: /host/var/log/pods/openshift-scanning_logger-*/scan-printer/*.log
+          sourceType: openshift:debug
           whiteList: \.log$
         - index: rh_osd_debug_node
           path: /host/var/log/pods/default_ip-*-debug_*/container-*/*.log


### PR DESCRIPTION
Two lightweight sidecar containers now handle the logging for the logger pod in the openshift-scanning namespace.

Once splunk-forwarder-operator reads the logs from these sidecar container's stdout log files, there will be no reason for the logger pod to mount the host filesystem or have elevated privileges anymore. This is related to [OSD-12910](https://issues.redhat.com//browse/OSD-12910) and OSD-12911.