### PR TITLE
[OSD-13628] Label openshift-security for PSS.

### DIFF
--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -46,6 +46,8 @@ objects:
         name: openshift-security
         annotations:
           openshift.io/node-selector: ''
+        labels:
+          pod-security.kubernetes.io/enforce: 'privileged'
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:


### PR DESCRIPTION
The openshift-security namespace hosts the audit-exporter and splunkforwarder pods that both require elevated privileges to run.

In 4.12 the PSS enforcement was changed to enforce 'restricted' by default: https://github.com/openshift/cluster-kube-apiserver-operator/pull/1369/

This prevents the pods from running in this namespace, because the splunkforwarder SCC can not be used.

By adding the 'pod-security.kubernetes.io/enforce=privileged' label to the namespace the privileged SCC can be used and the pods will be able to start.