### PR TITLE
Rollout fix for panic in splunk-audit-exporter

### DIFF
--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -553,7 +553,7 @@ objects:
                 limits:
                   cpu: 50m
                   memory: 128Mi
-              image: quay.io/app-sre/splunk-audit-exporter@sha256:ddbe0a544e11698848000e93e30f14d67c43ddd329853db9982dc99bbff45127
+              image: quay.io/app-sre/splunk-audit-exporter@sha256:513f7f360ee7c2d115810ba326d35e6835d9c6da2b082122f3ef37648f5fa306
               imagePullPolicy: Always
               securityContext:
                 privileged: true


### PR DESCRIPTION
This fix updates the image of splunk-audit-exporter to contain the fixes from https://gitlab.cee.redhat.com/service/splunk-audit-exporter/-/merge_requests/8

Currently, the audit exporter on some production clusters is constantly CrashLooping with logs like:
```
❯ k logs -n openshift-security audit-exporter-f6f46 -f
2022/11/19 18:17:30 policy loaded with 27 rules
2022/11/19 18:17:30 writing output to /var/log/osd-audit/audit.log
2022/11/19 18:17:30 resuming from last logged event 2022-11-19 17:24:15.793562 +0000 UTC
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x48 pc=0xa71998]

goroutine 119 [running]:
audit-exporter/pkg/policy.apiGroupMatches(...)
	audit-exporter/pkg/policy/util.go:22
audit-exporter/pkg/policy.objectMatches(0x0, 0xc000018d10, {0x0, 0x0, 0x0})
	audit-exporter/pkg/policy/util.go:60 +0x38
audit-exporter/pkg/policy.findMatches({0xc0003f2c00, 0xe, 0x0}, 0xc0007f3ac0)
	audit-exporter/pkg/policy/policy.go:135 +0x12a
audit-exporter/pkg/policy.(*Policy).CleanFields.func1(0xc0007f3ac0)
	audit-exporter/pkg/policy/policy.go:107 +0x5e
audit-exporter/pkg/filter.NewEventFilter.func1.1(0xc0007f3ac0)
	audit-exporter/pkg/filter/util.go:69 +0x3c
audit-exporter/pkg/filter.Filter.done.func1(0x0)
	audit-exporter/pkg/filter/util.go:86 +0x6d
audit-exporter/pkg/filter.Filter.receive(0xc0003faa50, 0x0)
	audit-exporter/pkg/filter/util.go:78 +0x5d
audit-exporter/pkg/filter.Events.parallel.func1(0x0)
	audit-exporter/pkg/filter/util.go:54 +0x25
audit-exporter/pkg/util.WorkPool.func1()
	audit-exporter/pkg/util/util.go:29 +0x22
audit-exporter/pkg/util.worker.wait(0x0, 0x0)
	audit-exporter/pkg/util/util.go:24 +0x53
created by audit-exporter/pkg/util.workers
	audit-exporter/pkg/util/util.go:19 +0x4c
```