### PR TITLE
splunk-audit-exporter: expose NonSystemChangeValidationWebhookConfiguration as metric

### DIFF
--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -1032,8 +1032,7 @@ objects:
             protocol: TCP
             targetPort: 9090
         selector:
-          matchLabels:
-            app: audit-exporter
+          app: audit-exporter
         sessionAffinity: None
         type: ClusterIP
     - apiVersion: monitoring.coreos.com/v1

--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -551,11 +551,11 @@ objects:
               - --tls-private-key-file=/certs/tls.key
               resources:
                 requests:
-                  cpu: 10m
-                  memory: 32Mi
+                  cpu: 100m
+                  memory: 256Mi
                 limits:
-                  cpu: 50m
-                  memory: 128Mi
+                  cpu: 100m
+                  memory: 256Mi
               image: quay.io/app-sre/splunk-audit-exporter@sha256:bbca8dfd77d15c6dde3495985c1a75354ad79339ecba6820e7ceef2282422964
               imagePullPolicy: Always
               securityContext:

--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -556,7 +556,7 @@ objects:
                 limits:
                   cpu: 50m
                   memory: 128Mi
-              image: quay.io/app-sre/splunk-audit-exporter@sha256:513f7f360ee7c2d115810ba326d35e6835d9c6da2b082122f3ef37648f5fa306
+              image: quay.io/app-sre/splunk-audit-exporter@sha256:bbca8dfd77d15c6dde3495985c1a75354ad79339ecba6820e7ceef2282422964
               imagePullPolicy: Always
               securityContext:
                 privileged: true
@@ -1016,62 +1016,62 @@ objects:
                 responseStatus:
                   codes: ["!403"]
               alert: NonSystemChangeValidationWebhookConfiguration  
-- apiVersion: v1
-  kind: Service
-  metadata:
-    labels: 
-      app: audit-exporter
-    name: audit-exporter
-    namespace: openshift-security
-    annotations:
-       service.beta.openshift.io/serving-cert-secret-name: audit-exporter-certs
-  spec:
-    ports:
-    - name: metrics
-      port: 9090
-      protocol: TCP
-      targetPort: 9090
-    selector:
-      matchLabels:
-        app: audit-exporter
-    sessionAffinity: None
-    type: ClusterIP
-- apiVersion: monitoring.coreos.com/v1
-  kind: ServiceMonitor
-  metadata:
-    name: audit-exporter
-    namespace: openshift-security
-  spec:
-    endpoints:
-    - path: /metrics
-      port: metrics
-      scheme: https
-      tlsConfig:
-        caFile: /var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt
-        serverName: audit-exporter.openshift-security.svc
-    namespaceSelector: {}
-    selector:
-      matchLabels:
-        app: audit-exporter
-- apiVersion: rbac.authorization.k8s.io/v1
-  kind: RoleBinding
-  metadata:
-    name: prometheus-k8s
-    namespace: openshift-security
-  roleRef:
-    apiGroup: rbac.authorization.k8s.io
-    kind: Role
-    name: prometheus-k8s
-  subjects:
-  - kind: ServiceAccount
-    name: prometheus-k8s
-    namespace: openshift-monitoring
-- apiVersion: rbac.authorization.k8s.io/v1
-  kind: Role
-  metadata:
-    name: prometheus-k8s
-    namespace: openshift-security
-  rules:
-  - apiGroups: ['']
-    resources: ['services','endpoints','pods','servicemonitors']
-    verbs: ['get','list','watch']
+    - apiVersion: v1
+      kind: Service
+      metadata:
+        labels:
+          app: audit-exporter
+        name: audit-exporter
+        namespace: openshift-security
+        annotations:
+          service.beta.openshift.io/serving-cert-secret-name: audit-exporter-certs
+      spec:
+        ports:
+          - name: metrics
+            port: 9090
+            protocol: TCP
+            targetPort: 9090
+        selector:
+          matchLabels:
+            app: audit-exporter
+        sessionAffinity: None
+        type: ClusterIP
+    - apiVersion: monitoring.coreos.com/v1
+      kind: ServiceMonitor
+      metadata:
+        name: audit-exporter
+        namespace: openshift-security
+      spec:
+        endpoints:
+          - path: /metrics
+            port: metrics
+            scheme: https
+            tlsConfig:
+              caFile: /var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt
+              serverName: audit-exporter.openshift-security.svc
+        namespaceSelector: {}
+        selector:
+          matchLabels:
+            app: audit-exporter
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: prometheus-k8s
+        namespace: openshift-security
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: Role
+        name: prometheus-k8s
+      subjects:
+        - kind: ServiceAccount
+          name: prometheus-k8s
+          namespace: openshift-monitoring
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: prometheus-k8s
+        namespace: openshift-security
+      rules:
+        - apiGroups: [""]
+          resources: ["services", "endpoints", "pods", "servicemonitors"]
+          verbs: ["get", "list", "watch"]

--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -48,6 +48,7 @@ objects:
           openshift.io/node-selector: ''
         labels:
           pod-security.kubernetes.io/enforce: 'privileged'
+          openshift.io/cluster-monitoring: "true"
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -546,6 +547,8 @@ objects:
               command:
               - /bin/audit-exporter
               - --log-file=/var/log/osd-audit/audit.log
+              - --tls-cert-file=/certs/tls.crt
+              - --tls-private-key-file=/certs/tls.key
               resources:
                 requests:
                   cpu: 10m
@@ -563,9 +566,16 @@ objects:
                 name: config
               - mountPath: /var/log
                 name: logs
+              - mountPath: /certs
+                name: tls-certs-secret
+                readOnly: true
             nodeSelector:
               node-role.kubernetes.io/master: ''
             restartPolicy: Always
+            ports:
+            - containerPort: 9090
+              name: metrics
+              protocol: TCP
             terminationGracePeriodSeconds: 5
             tolerations:
             - operator: Exists
@@ -573,6 +583,9 @@ objects:
             - name: config
               configMap:
                 name: osd-audit-policy
+            - name: tls-certs-secret
+              secret:
+                secretName: audit-exporter-certs
             - name: logs
               hostPath:
                 type: Directory
@@ -583,7 +596,7 @@ objects:
         name: osd-audit-policy
         namespace: openshift-security
       data:
-        policy.yaml: |
+        policy.yaml: |          
           rules:
           # drop leases, tokenreviews, subjectaccessreviews, user self-lookup (~500k/day)
           - level: None
@@ -992,4 +1005,73 @@ objects:
                 lastSyncTimestamp: remove
                 storageBucket:
                   lastSyncTimestamp: remove
-
+          exposeAsMetric:
+            - eventselector:
+                users:
+                  usernames: ["!system:*"]
+                verbs: ["delete", "update", "patch"]
+                objectReferences:
+                  - names: ["sre-*", "*openshift.io"]
+                    resources: ["validatingwebhookconfigurations"]
+                responseStatus:
+                  codes: ["!403"]
+              alert: NonSystemChangeValidationWebhookConfiguration  
+- apiVersion: v1
+  kind: Service
+  metadata:
+    labels: 
+      app: audit-exporter
+    name: audit-exporter
+    namespace: openshift-security
+    annotations:
+       service.beta.openshift.io/serving-cert-secret-name: audit-exporter-certs
+  spec:
+    ports:
+    - name: metrics
+      port: 9090
+      protocol: TCP
+      targetPort: 9090
+    selector:
+      matchLabels:
+        app: audit-exporter
+    sessionAffinity: None
+    type: ClusterIP
+- apiVersion: monitoring.coreos.com/v1
+  kind: ServiceMonitor
+  metadata:
+    name: audit-exporter
+    namespace: openshift-security
+  spec:
+    endpoints:
+    - path: /metrics
+      port: metrics
+      scheme: https
+      tlsConfig:
+        caFile: /var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt
+        serverName: audit-exporter.openshift-security.svc
+    namespaceSelector: {}
+    selector:
+      matchLabels:
+        app: audit-exporter
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: RoleBinding
+  metadata:
+    name: prometheus-k8s
+    namespace: openshift-security
+  roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: Role
+    name: prometheus-k8s
+  subjects:
+  - kind: ServiceAccount
+    name: prometheus-k8s
+    namespace: openshift-monitoring
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: Role
+  metadata:
+    name: prometheus-k8s
+    namespace: openshift-security
+  rules:
+  - apiGroups: ['']
+    resources: ['services','endpoints','pods','servicemonitors']
+    verbs: ['get','list','watch']


### PR DESCRIPTION
**What?**
This PR updates `splunk-audit-exporter` to the latest version which allows exposing selected events as metric using the policy file. 

Along with updating the `splunk-audit-exporter` version, this PR adds the following objects to allow HTTPs scraping:
- ServiceMonitor
- RoleBinding for prometheus
- Role for prometheus

The daemonset for the `splunk-audit-exporter` is extended to receive TLS cert & key and to open up port 9090.

The namespace `openshift-security` namespace also receives an additional label to allow prometheus scraping.

**Why?**

This PR updates `splunk-audit-exporter` to expose the equivalent of the `Non-System Change ValidatingWebhookConfigurations` webhook set in splunk as metric within the cluster (implemented in [OSD-10551](https://issues.redhat.com/browse/OSD-10551)). 

This particular metric will be used in [OSD-13558](https://issues.redhat.com/browse/OSD-13558) and [OSD-13559](https://issues.redhat.com/browse/OSD-13559) to trigger automated service logs for the event corresponding to a `NonSystemChangeValidatingWebhookConfiguration`.  

**Validation**

Tested by applying all updated ressources as below to a stage cluster, and verifying that the metric gets exposed and scraped when editing validation webhooks:
`oc edit validatingwebhookconfigurations/sre-pod-validation --as backplane-cluster-admin`