### PR TITLE
Add Prometheus metric for UserCreatedIngressController alert

### DIFF
--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -1015,7 +1015,16 @@ objects:
                     resources: ["validatingwebhookconfigurations"]
                 responseStatus:
                   codes: ["!403"]
-              alert: NonSystemChangeValidationWebhookConfiguration  
+              alert: NonSystemChangeValidationWebhookConfiguration
+            - eventselector:
+                users:
+                  usernames: ["!system:*"]
+                verbs: ["create"]
+                objectReferences:
+                  - resources: ["ingresscontrollers"]
+                responseStatus:
+                  codes: ["!403"]
+              alert: UserCreatedIngressControllerDetected
     - apiVersion: v1
       kind: Service
       metadata:


### PR DESCRIPTION
https://issues.redhat.com/browse/OSD-12599
Exposes the `UserCreatedIngressControllerDetected` alert for the following Splunk condition: 
```
"objectReferences.resources"="ingresscontrollers" verb="create" "user.username"!="system*"
```
Where users create ingress controllers manually, not managed by the CIO or CDO.

To test, make yourself cluster-admin:
```
oc adm policy add-cluster-role-to-user cluster-admin $(oc whoami) --as backplane-cluster-admin
```
Update the `exposeAsMetric` configMap to the updated version in the diff, bounce the pods,
 Then add the yaml file below as an `ingresscontroller` in the `openshift-ingress-operator` namespace, and then query for: 
```
sum(max_over_time(splunkforwarder_audit_filter_exposed_splunk_event_total{alert="UserCreatedIngressControllerDetected"}[5m]) or vector(0)) - sum(max_over_time(splunkforwarder_audit_filter_exposed_splunk_event_total{alert="UserCreatedIngressControllerDetected"}[5m] offset 5m) or vector(0)) > 0
```

```
apiVersion: operator.openshift.io/v1
kind: IngressController
metadata:
  name: dev
  namespace: openshift-ingress-operator
spec:
  domain: dev.yourcluster.yourdomain
  nodePlacement:
    nodeSelector:
      matchLabels:
        my/zone: dev
        node-role.kubernetes.io/infra: ''
  routeSelector:
    matchLabels:
      my/env: dev
  routeAdmission:
    namespaceOwnership: InterNamespaceAllowed
```