### PR TITLE
[OSD-15417]Add new path for backplane

### DIFF
--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -358,6 +358,10 @@ objects:
           index: openshift_managed_backplane_prod
           sourceType: _json
           whiteList: \.log$
+        - path: /host/var/lib/kubelet/pods/*/volumes/kubernetes.io~*/pvc-*/mount/backplane-audit.log
+          index: openshift_managed_backplane_prod
+          sourceType: _json
+          whiteList: \.log$
 
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet


### PR DESCRIPTION
Backplane on hives now has different path with clusters upgraded to 4.12.X