### PR TITLE
Rojasreinold revert to json logging

### DIFF
--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -349,11 +349,11 @@ objects:
         - path: /host/var/log/pods/openshift-scanning_logger-*/pod-printer/*.log
           index: openshift_managed_pod_creation
           whiteList: \.log$
-          sourceType: openshift:debug
+          sourceType: _json
         - path: /host/var/log/pods/openshift-scanning_logger-*/scan-printer/*.log
           index: openshift_managed_malware_scan
           whiteList: \.log$
-          sourceType: openshift:debug
+          sourceType: _json
         - path: /host/var/lib/kubelet/pods/*/volumes/kubernetes.io~*/pvc-*/backplane-audit.log
           index: openshift_managed_backplane_prod
           sourceType: _json
@@ -611,11 +611,11 @@ objects:
           whiteList: \.log$
         - index: rh_osd_pod_creation
           path: /host/var/log/pods/openshift-scanning_logger-*/pod-printer/*.log
-          sourceType: openshift:debug
+          sourceType: _json
           whiteList: \.log$
         - index: rh_osd_malware_scan
           path: /host/var/log/pods/openshift-scanning_logger-*/scan-printer/*.log
-          sourceType: openshift:debug
+          sourceType: _json
           whiteList: \.log$
         - index: rh_osd_debug_node
           path: /host/var/log/pods/default_ip-*-debug_*/container-*/*.log

--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -349,11 +349,11 @@ objects:
         - path: /host/var/log/pods/openshift-scanning_logger-*/pod-printer/*.log
           index: openshift_managed_pod_creation
           whiteList: \.log$
-          sourceType: _json
+          sourceType: openshift:debug
         - path: /host/var/log/pods/openshift-scanning_logger-*/scan-printer/*.log
           index: openshift_managed_malware_scan
           whiteList: \.log$
-          sourceType: _json
+          sourceType: openshift:debug
         - path: /host/var/lib/kubelet/pods/*/volumes/kubernetes.io~*/pvc-*/backplane-audit.log
           index: openshift_managed_backplane_prod
           sourceType: _json


### PR DESCRIPTION
Partially reverts the logging change from https://github.com/openshift/splunk-forwarder-operator/pull/160 for the sourcetype back to _json to fix the parsing of the lob in splunk.  This relates to [OSD-14695](https://issues.redhat.com/browse/OSD-14695)