### PR TITLE
Modify openshift-security NS labels not to generate alerts

### DIFF
--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -48,6 +48,8 @@ objects:
           openshift.io/node-selector: ''
         labels:
           pod-security.kubernetes.io/enforce: 'privileged'
+          pod-security.kubernetes.io/audit: 'privileged'
+          pod-security.kubernetes.io/warn: 'privileged'
           openshift.io/cluster-monitoring: "true"
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole


### PR DESCRIPTION
OpenShift clusters configure their default PSa policy such as:

```
enforce: privileged
audit: restricted
warn: restricted
```

This way we are able to track PSa violations on the audit level with the metrics PSa provides in order to figure out which workloads need to be fixed before we are able to turn our clusters to restricted enforcement everywhere.

This patch fixes the namespace labels so that the workloads in the namespace don't increase the metrics we base our alerts on.