### PR TITLE
Remove CPU requests and limits from audit-exporter daemonset

### DIFF
--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -791,10 +791,8 @@ objects:
               - --tls-private-key-file=/certs/tls.key
               resources:
                 requests:
-                  cpu: 100m
                   memory: 256Mi
                 limits:
-                  cpu: 100m
                   memory: 256Mi
               image: quay.io/app-sre/splunk-audit-exporter@sha256:bbca8dfd77d15c6dde3495985c1a75354ad79339ecba6820e7ceef2282422964
               imagePullPolicy: Always


### PR DESCRIPTION
CPU limits can't reasonably be determined in a one-size-fits all manner, removing them is consistent with other cluster components.