### PR TITLE
Make catalogsource compatible with restricted SCC enforcement

### DIFF
--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -152,6 +152,8 @@ objects:
         namespace: openshift-splunk-forwarder-operator
       spec:
         sourceType: grpc
+        grpcPodConfig:
+          securityContextConfig: restricted
         image: ${REPO_DIGEST}
         displayName: splunk-forwarder-operator Registry
         publisher: SRE


### PR DESCRIPTION
* Restricted SCC enforcement will be added with OCP 4.14
* Updating the catalogsource to allow the operator to get deployed
* Clusters that don't support the setting (<4.12) will ignore it

Jira: [OSD-15616](https://issues.redhat.com//browse/OSD-15616)