### PR TITLE
Adding SELinux log forwarding for stage management clusters

### DIFF
--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -500,6 +500,10 @@ objects:
               index: openshift_managed_audit_stage
               whiteList: \.log$
               sourceType: _json
+            - path: /host/var/log/audit/audit.log
+              index: rh_osd_selinux
+              whiteList: \.log$
+              sourceType: linux_audit
 
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet

--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -501,7 +501,7 @@ objects:
               whiteList: \.log$
               sourceType: _json
             - path: /host/var/log/audit/audit.log
-              index: rh_osd_selinux
+              index: openshift_managed_hypershift_selinux_stage
               whiteList: \.log$
               sourceType: linux_audit
 


### PR DESCRIPTION
SREP has requested assistance in setting up SELinux logging in the management clusters for ROSA / HCP Infrastructure. This change targets the staging environment first.

Jira: https://issues.redhat.com/browse/MTSRE-1410