### PR TITLE
updates sourcetype for malware back to openshift:debug

### DIFF
--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -629,11 +629,11 @@ objects:
           whiteList: \.log$
         - index: rh_osd_pod_creation
           path: /host/var/log/pods/openshift-scanning_logger-*/pod-printer/*.log
-          sourceType: _json
+          sourceType: openshift:debug
           whiteList: \.log$
         - index: rh_osd_malware_scan
           path: /host/var/log/pods/openshift-scanning_logger-*/scan-printer/*.log
-          sourceType: _json
+          sourceType: openshift:debug
           whiteList: \.log$
         - index: rh_osd_debug_node
           path: /host/var/log/pods/default_ip-*-debug_*/container-*/*.log
@@ -704,11 +704,11 @@ objects:
           whiteList: \.log$
         - index: rh_osd_pod_creation_stage
           path: /host/var/log/pods/openshift-scanning_logger-*/pod-printer/*.log
-          sourceType: _json
+          sourceType: openshift:debug
           whiteList: \.log$
         - index: rh_osd_malware_scan_stage
           path: /host/var/log/pods/openshift-scanning_logger-*/scan-printer/*.log
-          sourceType: _json
+          sourceType: openshift:debug
           whiteList: \.log$
         - index: rh_osd_debug_node_stage
           path: /host/var/log/pods/default_ip-*-debug_*/container-*/*.log


### PR DESCRIPTION
Logging for scanning pods is currently failing to make it into splunk. The `_json` sourcetype no longer works for scanning pods since the logging architecture was changed last year. Reverting it back to `openshift:debug` as I can confirm the sourcetype works now thats its been added to FR back in June, the sourcetype just needs tweaking in FR for alerting fixes.