### PR TITLE
Added upgrade test to e2e tests 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,13 +6,12 @@ require (
 	github.com/onsi/ginkgo/v2 v2.9.5
 	github.com/onsi/gomega v1.27.7
 	github.com/openshift/operator-custom-metrics v0.5.0
-	github.com/openshift/osde2e-common v0.0.0-20230621125319-93f8f034f3aa
+	github.com/openshift/osde2e-common v0.0.0-20230828192052-1b1a774e2df6
 	github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.58.0
 	github.com/prometheus-operator/prometheus-operator/pkg/client v0.58.0
 	k8s.io/apimachinery v0.27.2
 	k8s.io/client-go v0.27.2
 	sigs.k8s.io/controller-runtime v0.15.0
-	sigs.k8s.io/e2e-framework v0.2.0
 )
 
 require (
@@ -21,6 +20,7 @@ require (
 	github.com/google/pprof v0.0.0-20210720184732-4bb14d4b1be1 // indirect
 	github.com/moby/spdystream v0.2.0 // indirect
 	golang.org/x/tools v0.9.1 // indirect
+	sigs.k8s.io/e2e-framework v0.2.0 // indirect
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -186,8 +186,8 @@ github.com/openshift/api v0.0.0-20220414050251-a83e6f8f1d50/go.mod h1:F/eU6jgr6Q
 github.com/openshift/build-machinery-go v0.0.0-20211213093930-7e33a7eb4ce3/go.mod h1:b1BuldmJlbA/xYtdZvKi+7j5YGB44qJUJDZ9zwiNCfE=
 github.com/openshift/operator-custom-metrics v0.5.0 h1:iRZ6e3HvGSxw1dZgnY5emEN6fg9u/OhHfEC+u3ovhSE=
 github.com/openshift/operator-custom-metrics v0.5.0/go.mod h1:garCvCZK9l0RS0vCcz5anKsJSU60XgizYXllbMjRW5M=
-github.com/openshift/osde2e-common v0.0.0-20230621125319-93f8f034f3aa h1:qfj0cSkZ7Ja9+ahYmiQdXoT8lrH6tTcRV6jspyb5Q4I=
-github.com/openshift/osde2e-common v0.0.0-20230621125319-93f8f034f3aa/go.mod h1:qP+tI/gaFODlcRTSzD7IL3Z6Eh7C/eKdxK4z7J/bYNE=
+github.com/openshift/osde2e-common v0.0.0-20230828192052-1b1a774e2df6 h1:aYc2LFk/Ued/HaivX7FuUXxJ6HwVdeqS/HyfOVFnl8A=
+github.com/openshift/osde2e-common v0.0.0-20230828192052-1b1a774e2df6/go.mod h1:bkreMB6T7SoOuEceXyXCvMHF4/9augfiWsixGaQ/Yo0=
 github.com/operator-framework/operator-lib v0.11.0 h1:eYzqpiOfq9WBI4Trddisiq/X9BwCisZd3rIzmHRC9Z8=
 github.com/operator-framework/operator-lib v0.11.0/go.mod h1:RpyKhFAoG6DmKTDIwMuO6pI3LRc8IE9rxEYWy476o6g=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/osde2e/splunk_forwarder_operator_tests.go
+++ b/osde2e/splunk_forwarder_operator_tests.go
@@ -116,10 +116,6 @@ var _ = ginkgo.Describe("Splunk Forwarder Operator", ginkgo.Ordered, func() {
 			return false
 		}).WithTimeout(time.Duration(300)*time.Second).WithPolling(time.Duration(30)*time.Second).Should(BeTrue(), "CSV %s should exist and have Succeeded status", operatorName)
 
-		ginkgo.By("testing operator upgrade")
-		err = k8s.UpgradeOperator(ctx, "openshift-"+operatorName, operatorNamespace)
-		Expect(err).NotTo(HaveOccurred(), "operator upgrade failed")
-
 	})
 
 	sf := makeMinimalSplunkforwarder(testsplunkforwarder)
@@ -140,6 +136,12 @@ var _ = ginkgo.Describe("Splunk Forwarder Operator", ginkgo.Ordered, func() {
 		Expect(sfv1alpha1.AddToScheme(impersonatedResourceClient.GetScheme())).Should(BeNil(), "unable to register sfv1alpha1 api scheme")
 		err := impersonatedResourceClient.WithNamespace(operatorNamespace).Create(ctx, &dsf)
 		Expect(apierrors.IsForbidden(err)).To(BeTrue(), "expected err to be forbidden, got: %v", err)
+	})
+
+	ginkgo.It("can be upgraded", func(ctx context.Context) {
+		ginkgo.By("forcing operator upgrade")
+		err := k8s.UpgradeOperator(ctx, "openshift-"+operatorName, operatorNamespace)
+		Expect(err).NotTo(HaveOccurred(), "operator upgrade failed")
 	})
 
 })

--- a/osde2e/splunk_forwarder_operator_tests.go
+++ b/osde2e/splunk_forwarder_operator_tests.go
@@ -116,10 +116,10 @@ var _ = ginkgo.Describe("Splunk Forwarder Operator", ginkgo.Ordered, func() {
 			return false
 		}).WithTimeout(time.Duration(300)*time.Second).WithPolling(time.Duration(30)*time.Second).Should(BeTrue(), "CSV %s should exist and have Succeeded status", operatorName)
 
-		// TODO: post osde2e-common library add upgrade check
-		//checkUpgrade(helper.New(), "openshift-splunk-forwarder-operator",
-		//	"openshift-splunk-forwarder-operator", "splunk-forwarder-operator",
-		//	"splunk-forwarder-operator-catalog")
+		ginkgo.By("testing operator upgrade")
+		err = k8s.UpgradeOperator(ctx, "openshift-"+operatorName, operatorNamespace)
+		Expect(err).NotTo(HaveOccurred(), "operator upgrade failed")
+
 	})
 
 	sf := makeMinimalSplunkforwarder(testsplunkforwarder)


### PR DESCRIPTION
Operator upgrade test was removed from e2e tests due to dependency on the new osde2e-common library implementation. 


This change completes the TODO item and adds assertion to verify operator upgrade. It downgrades operator to n-1 version, which kicks off an upgrade. Test asserts that this succeeds. 


https://issues.redhat.com/browse/SDCICD-1102 