### PR TITLE
(1/3) Remove exposeAsMetric temporarily before bumping splunk-audit-exporter

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -3,7 +3,7 @@ COPY . /go/src/github.com/openshift/splunk-forwarder-operator
 WORKDIR /go/src/github.com/openshift/splunk-forwarder-operator
 RUN make go-build
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.8-1037
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.8-1072
 ENV OPERATOR_PATH=/go/src/github.com/openshift/splunk-forwarder-operator \
     OPERATOR_BIN=splunk-forwarder-operator
 

--- a/build/Dockerfile.olm-registry
+++ b/build/Dockerfile.olm-registry
@@ -4,7 +4,7 @@ COPY ${SAAS_OPERATOR_DIR} manifests
 RUN initializer --permissive
 
 # ubi-micro does not work for clusters with fips enabled unless we make OpenSSL available
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.8-1037
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.8-1072
 
 COPY --from=builder /bin/registry-server /bin/registry-server
 COPY --from=builder /bin/grpc_health_probe /bin/grpc_health_probe

--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -1251,26 +1251,6 @@ objects:
                 lastSyncTimestamp: remove
                 storageBucket:
                   lastSyncTimestamp: remove
-          exposeAsMetric:
-            - eventselector:
-                users:
-                  usernames: ["!system:*"]
-                verbs: ["delete", "update", "patch"]
-                objectReferences:
-                  - names: ["sre-*", "*openshift.io"]
-                    resources: ["validatingwebhookconfigurations"]
-                responseStatus:
-                  codes: ["!403"]
-              alert: NonSystemChangeValidationWebhookConfiguration
-            - eventselector:
-                users:
-                  usernames: ["!system:*"]
-                verbs: ["create"]
-                objectReferences:
-                  - resources: ["ingresscontrollers"]
-                responseStatus:
-                  codes: ["!403"]
-              alert: UserCreatedIngressControllerDetected
     - apiVersion: v1
       kind: Service
       metadata:


### PR DESCRIPTION
https://issues.redhat.com/browse/OSD-14962 

**What?**
Removes the exposeAsMetric part of the configmap temporarily before bumping the splunk-audit-exporter version.

With the splunk-audit-exporter change, the exposeAsMetric selectors changed. To ensure there is no time interval in which the splunk-audit-exporter uses an exposeAsMetric configmap meant for a different version, I'm upgrading as follows:
- **[current] remove exposeAsMetric from the configmap**: this PR 
- update splunk-audit-exporter: https://github.com/openshift/splunk-forwarder-operator/pull/209
- re-add exposeAsMetric in the new format: https://github.com/openshift/splunk-forwarder-operator/pull/207 