### PR TITLE
(3/3) Reenable exposeasmetric

### DIFF
--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -1255,6 +1255,35 @@ objects:
                 lastSyncTimestamp: remove
                 storageBucket:
                   lastSyncTimestamp: remove
+          exposeAsMetric:
+            - eventSelector:
+                user:
+                  username: 
+                    NotIn: ["system:*"]
+                verb: 
+                  In: ["delete", "update", "patch"]
+                objectReference:
+                  name: 
+                    In: ["sre-*", "*openshift.io"]
+                  resource: 
+                    In: ["validatingwebhookconfigurations"]
+                responseStatus:
+                  code: 
+                    NotIn: ["403"]
+              alert: NonSystemChangeValidationWebhookConfiguration
+            - eventSelector:
+                  user:
+                    username: 
+                      NotIn: ["system:*"]
+                  verb: 
+                    In: ["create"]
+                  objectReference:
+                    resource: 
+                      In: ["ingresscontrollers"]
+                  responseStatus:
+                    code: 
+                      NotIn: ["403"]
+                alert: UserCreatedIngressControllerDetected
     - apiVersion: v1
       kind: Service
       metadata:


### PR DESCRIPTION
https://issues.redhat.com/browse/OSD-14962

To be merged after https://github.com/openshift/splunk-forwarder-operator/pull/209

**What?**
Re-adds event selectors with the new implementation.


With the splunk-audit-exporter change, the exposeAsMetric selectors changed. To ensure there is no time interval in which the splunk-audit-exporter uses an exposeAsMetric configmap meant for a different version, I'm upgrading as follows:
- remove exposeAsMetric from the configmap:https://github.com/openshift/splunk-forwarder-operator/pull/206
- update splunk-audit-exporter: https://github.com/openshift/splunk-forwarder-operator/pull/209
- **[THIS PR] re-add exposeAsMetric in the new format:** https://github.com/openshift/splunk-forwarder-operator/pull/207 