### PR TITLE
Forward stage management cluster OVN audit logs to Splunk

### DIFF
--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -504,6 +504,10 @@ objects:
               index: openshift_managed_hypershift_selinux_stage
               whiteList: \.log$
               sourceType: linux_audit
+            - path: /host/var/log/ovn/acl-audit-log.log
+              index: openshift_managed_audit_stage
+              sourceType: linux_audit
+              whiteList: \.log$
 
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet


### PR DESCRIPTION
Add a path to send OVN audit logs from stage management clusters to the Splunk index openshift_managed_audit_stage 

https://issues.redhat.com/browse/OSD-17336
https://issues.redhat.com/browse/OSD-17338 