### PR TITLE
(2/3) Bump splunk-audit-exporter to 60899f33d0db4994473a4946b5974bc91fe23b6ef335e13e32412a249bcc7f72

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -3,7 +3,7 @@ COPY . /go/src/github.com/openshift/splunk-forwarder-operator
 WORKDIR /go/src/github.com/openshift/splunk-forwarder-operator
 RUN make go-build
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.8-1037
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.8-1072
 ENV OPERATOR_PATH=/go/src/github.com/openshift/splunk-forwarder-operator \
     OPERATOR_BIN=splunk-forwarder-operator
 

--- a/build/Dockerfile.olm-registry
+++ b/build/Dockerfile.olm-registry
@@ -4,7 +4,7 @@ COPY ${SAAS_OPERATOR_DIR} manifests
 RUN initializer --permissive
 
 # ubi-micro does not work for clusters with fips enabled unless we make OpenSSL available
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.8-1037
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.8-1072
 
 COPY --from=builder /bin/registry-server /bin/registry-server
 COPY --from=builder /bin/grpc_health_probe /bin/grpc_health_probe

--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -806,7 +806,7 @@ objects:
                   memory: 256Mi
                 limits:
                   memory: 256Mi
-              image: quay.io/app-sre/splunk-audit-exporter@sha256:bbca8dfd77d15c6dde3495985c1a75354ad79339ecba6820e7ceef2282422964
+              image: quay.io/app-sre/splunk-audit-exporter@sha256:60899f33d0db4994473a4946b5974bc91fe23b6ef335e13e32412a249bcc7f72
               imagePullPolicy: Always
               securityContext:
                 privileged: true


### PR DESCRIPTION
https://issues.redhat.com/browse/OSD-14962 

**What?**
This PR bumps splunk-audit-exporter to support the new `exposeAsMetric` formatting.

With the splunk-audit-exporter change, the exposeAsMetric selectors changed. To ensure there is no time interval in which the splunk-audit-exporter uses an exposeAsMetric configmap meant for a different version, I'm upgrading as follows:
- remove exposeAsMetric from the configmap: https://github.com/openshift/splunk-forwarder-operator/pull/206
- **[this PR] update splunk-audit-exporter**
- re-add exposeAsMetric in the new format: https://github.com/openshift/splunk-forwarder-operator/pull/207 