### PR TITLE
Adding SELinux logging for production hypershift clusters

### DIFF
--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -596,7 +596,7 @@ objects:
               sourceType: _json
               whiteList: \.log$
             - path: /host/var/log/audit/audit.log
-              index: openshift_managed_hypershift_selinux_prod
+              index: openshift_managed_hypershift_selinux
               whiteList: \.log$
               sourceType: linux_audit
 

--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -595,6 +595,10 @@ objects:
               index: openshift_managed_backplane_prod
               sourceType: _json
               whiteList: \.log$
+            - path: /host/var/log/audit/audit.log
+              index: openshift_managed_hypershift_selinux_prod
+              whiteList: \.log$
+              sourceType: linux_audit
 
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet


### PR DESCRIPTION
Adding SELinux Logs for production hypershift clusters.

EPIC: [SDE-3240](https://issues.redhat.com/browse/SDE-3420)

Jira: [MTSRE-1498](https://issues.redhat.com/browse/MTSRE-1498)
