### PR TITLE
Add OVN audit logging for HCP production

### DIFF
--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -603,6 +603,10 @@ objects:
               index: openshift_managed_hypershift_selinux
               whiteList: \.log$
               sourceType: linux_audit
+            - path: /host/var/log/ovn/acl-audit-log.log
+              index: openshift_managed_audit
+              sourceType: linux_audit
+              whiteList: \.log$
             - index: openshift_managed_hypershift_suricata
               path: /host/var/log/eve-*.json
               sourceType: _json


### PR DESCRIPTION
https://issues.redhat.com/browse/OSD-17337 

Forward OVN logs from HCP namespaces on management clusters to Splunk index "openshift_managed_audit"
