### PR TITLE
Add CPU limits to audit-exporter DaemonSet

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -3,7 +3,7 @@ COPY . /go/src/github.com/openshift/splunk-forwarder-operator
 WORKDIR /go/src/github.com/openshift/splunk-forwarder-operator
 RUN make go-build
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.9-1108
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.9-1108.1706795067
 ENV OPERATOR_PATH=/go/src/github.com/openshift/splunk-forwarder-operator \
     OPERATOR_BIN=splunk-forwarder-operator
 

--- a/build/Dockerfile.olm-registry
+++ b/build/Dockerfile.olm-registry
@@ -4,7 +4,7 @@ COPY ${SAAS_OPERATOR_DIR} manifests
 RUN initializer --permissive
 
 # ubi-micro does not work for clusters with fips enabled unless we make OpenSSL available
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.9-1108
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.9-1108.1706795067
 
 COPY --from=builder /bin/registry-server /bin/registry-server
 COPY --from=builder /bin/grpc_health_probe /bin/grpc_health_probe

--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -833,6 +833,7 @@ objects:
                 requests:
                   memory: 256Mi
                 limits:
+                  cpu: 100m
                   memory: 256Mi
               image: quay.io/app-sre/splunk-audit-exporter@sha256:6de8c1a27cecdafdc51c83e74bb960dc1f6564e76603e68338f05501d119b53b #0.1.157-22496d2
               imagePullPolicy: Always


### PR DESCRIPTION
Adds CPU limits to the audit-exporter daemonset, which has been observed degrading master nodes on certain clusters with elevated kube-apiserver activity.

The proposed limit of `100m` was computed by doubling the historical limit set [here](https://gitlab.cee.redhat.com/service/splunk-audit-exporter/-/blob/master/hack/deploy/daemonset-template.yaml#L30), so the workload has sufficient resources to operate.