### PR TITLE
updates forwarders to improve pod logs, adds low alert for forwarder errors

### DIFF
--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -266,6 +266,23 @@ objects:
         kind: ClusterRole
         name: splunk-forwarder-operator
 
+    - apiVersion: monitoring.coreos.com/v1
+      kind: PrometheusRule
+      metadata:
+        name: splunk-forwarder-component-unhealthy
+        namespace: openshift-security
+      spec:
+        groups:
+          - name: splunk-forwarder
+            rules:
+              - alert: SplunkForwarderComponentUnhealthy
+                annotations:
+                  message: One or more Splunk Forwarder Components are reporting unhealthy. This issue can impact log forwarding to Splunk, leading to log data loss.
+                expr: splunk_forwarder_component_unhealthy > 0
+                for: 15m
+                labels:
+                  severity: warning
+
     secretMappings:
     - sourceRef:
         name: splunk-auth
@@ -331,9 +348,9 @@ objects:
         namespace: openshift-security
       spec:
         image: quay.io/app-sre/splunk-forwarder
-        imageDigest: sha256:a1f0797cff3c507cea59ef9e3986e5d27bbc84275283722f5c49dcd0e659625a
+        imageDigest: sha256:af3a04144a2e92b35bfa0442e3ccae53ade9cb124c126eea7471dde2140d234a
         heavyForwarderImage: quay.io/app-sre/splunk-heavyforwarder
-        heavyForwarderDigest: sha256:720da34231210a6050b1f425b3f89591baa1fb752283cfe9c6d716e154efb7b4
+        heavyForwarderDigest: sha256:bdb8fafd368b86e9c8fa7d8e90ff3fb0f8d877694e4f1d65072821d68e24e65b
         useHeavyForwarder: false
         splunkLicenseAccepted: true
         filters:
@@ -422,9 +439,9 @@ objects:
         namespace: openshift-security
       spec:
         image: quay.io/app-sre/splunk-forwarder
-        imageDigest: sha256:a1f0797cff3c507cea59ef9e3986e5d27bbc84275283722f5c49dcd0e659625a
+        imageDigest: sha256:af3a04144a2e92b35bfa0442e3ccae53ade9cb124c126eea7471dde2140d234a
         heavyForwarderImage: quay.io/app-sre/splunk-heavyforwarder
-        heavyForwarderDigest: sha256:720da34231210a6050b1f425b3f89591baa1fb752283cfe9c6d716e154efb7b4
+        heavyForwarderDigest: sha256:bdb8fafd368b86e9c8fa7d8e90ff3fb0f8d877694e4f1d65072821d68e24e65b
         useHeavyForwarder: false
         splunkLicenseAccepted: true
         splunkInputs:
@@ -482,9 +499,9 @@ objects:
           namespace: openshift-security
         spec:
           image: quay.io/app-sre/splunk-forwarder
-          imageDigest: sha256:a1f0797cff3c507cea59ef9e3986e5d27bbc84275283722f5c49dcd0e659625a
+          imageDigest: sha256:af3a04144a2e92b35bfa0442e3ccae53ade9cb124c126eea7471dde2140d234a
           heavyForwarderImage: quay.io/app-sre/splunk-heavyforwarder
-          heavyForwarderDigest: sha256:720da34231210a6050b1f425b3f89591baa1fb752283cfe9c6d716e154efb7b4
+          heavyForwarderDigest: sha256:bdb8fafd368b86e9c8fa7d8e90ff3fb0f8d877694e4f1d65072821d68e24e65b
           useHeavyForwarder: false
           splunkLicenseAccepted: true
           splunkInputs:
@@ -558,9 +575,9 @@ objects:
           namespace: openshift-security
         spec:
           image: quay.io/app-sre/splunk-forwarder
-          imageDigest: sha256:a1f0797cff3c507cea59ef9e3986e5d27bbc84275283722f5c49dcd0e659625a
+          imageDigest: sha256:af3a04144a2e92b35bfa0442e3ccae53ade9cb124c126eea7471dde2140d234a
           heavyForwarderImage: quay.io/app-sre/splunk-heavyforwarder
-          heavyForwarderDigest: sha256:720da34231210a6050b1f425b3f89591baa1fb752283cfe9c6d716e154efb7b4
+          heavyForwarderDigest: sha256:bdb8fafd368b86e9c8fa7d8e90ff3fb0f8d877694e4f1d65072821d68e24e65b
           useHeavyForwarder: false
           splunkLicenseAccepted: true
           filters:
@@ -641,9 +658,9 @@ objects:
         namespace: openshift-security
       spec:
         image: quay.io/app-sre/splunk-forwarder
-        imageDigest: sha256:a1f0797cff3c507cea59ef9e3986e5d27bbc84275283722f5c49dcd0e659625a
+        imageDigest: sha256:af3a04144a2e92b35bfa0442e3ccae53ade9cb124c126eea7471dde2140d234a
         heavyForwarderImage: quay.io/app-sre/splunk-heavyforwarder
-        heavyForwarderDigest: sha256:720da34231210a6050b1f425b3f89591baa1fb752283cfe9c6d716e154efb7b4
+        heavyForwarderDigest: sha256:bdb8fafd368b86e9c8fa7d8e90ff3fb0f8d877694e4f1d65072821d68e24e65b
         useHeavyForwarder: false
         splunkLicenseAccepted: true
         splunkInputs:
@@ -720,9 +737,9 @@ objects:
         namespace: openshift-security
       spec:
         image: quay.io/app-sre/splunk-forwarder
-        imageDigest: sha256:a1f0797cff3c507cea59ef9e3986e5d27bbc84275283722f5c49dcd0e659625a
+        imageDigest: sha256:af3a04144a2e92b35bfa0442e3ccae53ade9cb124c126eea7471dde2140d234a
         heavyForwarderImage: quay.io/app-sre/splunk-heavyforwarder
-        heavyForwarderDigest: sha256:720da34231210a6050b1f425b3f89591baa1fb752283cfe9c6d716e154efb7b4
+        heavyForwarderDigest: sha256:bdb8fafd368b86e9c8fa7d8e90ff3fb0f8d877694e4f1d65072821d68e24e65b
         useHeavyForwarder: false
         splunkLicenseAccepted: true
         splunkInputs:


### PR DESCRIPTION
For:
[OSD-20974](https://issues.redhat.com//browse/OSD-20974)
[OSD-21059](https://issues.redhat.com//browse/OSD-21059)
[SDE-3870](https://issues.redhat.com//browse/SDE-3870) (PMR Epic)

Changes:
* Updates the forwarder images to include updates that add splunkd logs to pod log output to improve troubleshooting ([PR](https://github.com/openshift/splunk-forwarder-images/pull/25)
* Adds a low alert for when the Splunk forwarder is failing to aid in troubleshooting Splunk issues when logs are missing (part of PMR follow up)

Both updates have been tested with validation info in their respective cards above