### PR TITLE
minor change to trigger PR to fix registry image builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ downloading a credentials package from the specific Splunk application being use
 The credentials package is a tarball, so first extract the contents with `tar xvf splunkclouduf.spl`, then add the
 following fields in `outputs.conf`
 
-```
+```ini
 sslCertPath = $SPLUNK_HOME/etc/apps/splunkauth/default/server.pem
 sslRootCAPath = $SPLUNK_HOME/etc/apps/splunkauth/default/cacert.pem
 sslPassword = <Your SSL Password>


### PR DESCRIPTION
for OSD-21906, [ASIC-542](https://issues.redhat.com//browse/ASIC-542)

Changes in build pipeline broke the registry image build process due to skopeo version. AppSRE  has since remediated the issue but any builds that ran after or were run manually create bad CSV files in the saas-bundle repo. The saas bundle manifests have been fixed, we need to trigger a proper PR build to ensure clean images are built. This change is just a minor tweak in order to build images.