### PR TITLE
Adding jhealy and npecka to owners files as security team members

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -9,6 +9,8 @@ approvers:
 - dustman9000
 - gsleeman
 - sam-nguyen7
+- dem4gus
+- npecka
 maintainers:
 - jaybeeunix
 - wshearn

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -46,6 +46,8 @@ aliases:
     - jaybeeunix
     - sam-nguyen7
     - wshearn
+    - dem4gus
+    - npecka
   srep-functional-team-thor:
     - bmeng
     - MitaliBhalla

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -46,8 +46,6 @@ aliases:
     - jaybeeunix
     - sam-nguyen7
     - wshearn
-    - dem4gus
-    - npecka
   srep-functional-team-thor:
     - bmeng
     - MitaliBhalla


### PR DESCRIPTION
Adding Jhealy/Npecka to owners files as both members joined team security