### PR TITLE
Boilerplate konflux change

### DIFF
--- a/boilerplate/_lib/common.sh
+++ b/boilerplate/_lib/common.sh
@@ -197,4 +197,4 @@ if [[ -z "$LATEST_IMAGE_TAG" ]]; then
     fi
 fi
 # The public image location
-IMAGE_PULL_PATH=${IMAGE_PULL_PATH:-quay.io/redhat-services-prod/boilerplate/image/$IMAGE_NAME:$LATEST_IMAGE_TAG}
+IMAGE_PULL_PATH=${IMAGE_PULL_PATH:-quay.io/app-sre/$IMAGE_NAME:$LATEST_IMAGE_TAG}

--- a/boilerplate/_lib/common.sh
+++ b/boilerplate/_lib/common.sh
@@ -197,4 +197,4 @@ if [[ -z "$LATEST_IMAGE_TAG" ]]; then
     fi
 fi
 # The public image location
-IMAGE_PULL_PATH=${IMAGE_PULL_PATH:-quay.io/app-sre/$IMAGE_NAME:$LATEST_IMAGE_TAG}
+IMAGE_PULL_PATH=${IMAGE_PULL_PATH:-quay.io/redhat-services-prod/boilerplate/image/$IMAGE_NAME:$LATEST_IMAGE_TAG}

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/redhat-services-prod/boilerplate/image:image-v5.0.1 AS builder
+FROM quay.io/redhat-services-prod/boilerplate/image:6b4a1a8 AS builder
 COPY . /go/src/github.com/openshift/splunk-forwarder-operator
 WORKDIR /go/src/github.com/openshift/splunk-forwarder-operator
 RUN make go-build

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/app-sre/boilerplate:image-v5.0.1 AS builder
+FROM quay.io/redhat-services-prod/boilerplate/image:image-v5.0.1 AS builder
 COPY . /go/src/github.com/openshift/splunk-forwarder-operator
 WORKDIR /go/src/github.com/openshift/splunk-forwarder-operator
 RUN make go-build


### PR DESCRIPTION
Per [KONFLUX-3729](https://issues.redhat.com//browse/KONFLUX-3729) boilerplate location was changed to allow boilerplate in Konflux. It is now at quay.io/redhat-services-prod/boilerplate/image. Changing locations within SFO to match this new location.