### PR TITLE
Adding `priorityClassName` & `priority` within the DaemonSet

### DIFF
--- a/pkg/kube/daemonset.go
+++ b/pkg/kube/daemonset.go
@@ -38,11 +38,12 @@ func GenerateDaemonSet(instance *sfv1alpha1.SplunkForwarder) *appsv1.DaemonSet {
 			Value: licenseAccepted,
 		},
 		{
-		  Name: "HOSTNAME",
+			Name: "HOSTNAME",
 			ValueFrom: &corev1.EnvVarSource{
 				FieldRef: &corev1.ObjectFieldSelector{
-				FieldPath: "spec.nodeName",
-			}},
+					FieldPath: "spec.nodeName",
+				},
+			},
 		},
 	}
 
@@ -53,6 +54,8 @@ func GenerateDaemonSet(instance *sfv1alpha1.SplunkForwarder) *appsv1.DaemonSet {
 	} else {
 		volumes = GetVolumes(true, true, instance.Name)
 	}
+
+	var priority int32 = 2000001000
 
 	return &appsv1.DaemonSet{
 		ObjectMeta: metav1.ObjectMeta{
@@ -80,6 +83,8 @@ func GenerateDaemonSet(instance *sfv1alpha1.SplunkForwarder) *appsv1.DaemonSet {
 					},
 				},
 				Spec: corev1.PodSpec{
+					PriorityClassName: "system-node-critical",
+					Priority:          &priority,
 					NodeSelector: map[string]string{
 						"beta.kubernetes.io/os": "linux",
 					},

--- a/pkg/kube/daemonset_test.go
+++ b/pkg/kube/daemonset_test.go
@@ -16,6 +16,8 @@ func expectedDaemonSet(instance *sfv1alpha1.SplunkForwarder) *appsv1.DaemonSet {
 	var expectedRunAsUID int64 = 0
 	var expectedIsPrivContainer bool = true
 	var expectedTerminationGracePeriodSeconds int64 = 10
+	var expectedPriorityClassName string = "system-node-critical"
+	var expectedPriority int32 = 2000001000
 
 	useVolumeSecret := !instance.Spec.UseHeavyForwarder
 	var sfImage string
@@ -51,6 +53,8 @@ func expectedDaemonSet(instance *sfv1alpha1.SplunkForwarder) *appsv1.DaemonSet {
 					},
 				},
 				Spec: corev1.PodSpec{
+					PriorityClassName: expectedPriorityClassName,
+					Priority:          &expectedPriority,
 					NodeSelector: map[string]string{
 						"beta.kubernetes.io/os": "linux",
 					},
@@ -81,15 +85,15 @@ func expectedDaemonSet(instance *sfv1alpha1.SplunkForwarder) *appsv1.DaemonSet {
 									Name:  "SPLUNK_ACCEPT_LICENSE",
 									Value: "yes",
 								},
-						                {
-						                  Name: "HOSTNAME",
-						                        ValueFrom: &corev1.EnvVarSource{
-						                                FieldRef: &corev1.ObjectFieldSelector{
-							                                FieldPath: "spec.nodeName",
+								{
+									Name: "HOSTNAME",
+									ValueFrom: &corev1.EnvVarSource{
+										FieldRef: &corev1.ObjectFieldSelector{
+											FieldPath: "spec.nodeName",
 										},
-						                        },
+									},
 								},
-					                },
+							},
 
 							VolumeMounts: GetVolumeMounts(instance),
 
@@ -176,9 +180,9 @@ func TestGenerateDaemonSet(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			DeepEqualWithDiff(t,
-				expectedDaemonSet(tt.instance),
-				GenerateDaemonSet(tt.instance))
+			expected := expectedDaemonSet(tt.instance)
+			actual := GenerateDaemonSet(tt.instance)
+			DeepEqualWithDiff(t, expected, actual)
 		})
 	}
 }


### PR DESCRIPTION
### Overview:

We are updating the SplunkForwarder config so that the DaemonSet pods end up with `spec.priorityClassName: system-node-critical` when deploying them. Additionally we need to set the `spec.priority` value to  `2000001000`.

Ref: https://issues.redhat.com/browse/OSD-25984

### Modifications:

- `daemonset.go` (Code Changes)
	- Added `PriorityClassName` definition and set it to `"system-node-critical"` in the `PodSpec`.
	
	- Added `Priority` definition within `PodSpec`. Added the `priority` (`int32`) variable, set to `2000001000`.

	- This modification ensures that the `DaemonSet` pods are assigned the required `priorityClassName` and `priority` values when deployed.

	- Minor linting and formatting updates

- `daemonset_test.go` (Test Changes)
	- `func expectedDaemonSet` (Update)
		- Added `expectedPriorityClassName` set to  `system-node-critical`
		- Added `expectedPriority` set to `2000001000`

	-  Minor linting and formatting updates

----
### Local Test Results:

```
Running tool: /usr/local/go/bin/go test -timeout 30s -run ^TestGenerateDaemonSet$ github.com/openshift/splunk-forwarder-operator/pkg/kube

=== RUN   TestGenerateDaemonSet
=== RUN   TestGenerateDaemonSet/Without_HF,_with_image_digest
--- PASS: TestGenerateDaemonSet/Without_HF,_with_image_digest (0.00s)
=== RUN   TestGenerateDaemonSet/Without_HF,_with_digests
--- PASS: TestGenerateDaemonSet/Without_HF,_with_digests (0.00s)
=== RUN   TestGenerateDaemonSet/Test_Daemonset_without_HF,_with_tags
--- PASS: TestGenerateDaemonSet/Test_Daemonset_without_HF,_with_tags (0.00s)
=== RUN   TestGenerateDaemonSet/Test_Daemonset_without_HF,_with_tags_and_moot_HF_digest
--- PASS: TestGenerateDaemonSet/Test_Daemonset_without_HF,_with_tags_and_moot_HF_digest (0.00s)
=== RUN   TestGenerateDaemonSet/Without_HF,_digest_overrides_tag
--- PASS: TestGenerateDaemonSet/Without_HF,_digest_overrides_tag (0.00s)
=== RUN   TestGenerateDaemonSet/Without_HF,_digest_overrides_tag,_moot_HF_digest
--- PASS: TestGenerateDaemonSet/Without_HF,_digest_overrides_tag,_moot_HF_digest (0.00s)
=== RUN   TestGenerateDaemonSet/With_HF,_with_image_digest
--- PASS: TestGenerateDaemonSet/With_HF,_with_image_digest (0.00s)
=== RUN   TestGenerateDaemonSet/With_HF,_with_digests
--- PASS: TestGenerateDaemonSet/With_HF,_with_digests (0.00s)
=== RUN   TestGenerateDaemonSet/Test_Daemonset,_with_HF,_with_tags
--- PASS: TestGenerateDaemonSet/Test_Daemonset,_with_HF,_with_tags (0.00s)
=== RUN   TestGenerateDaemonSet/With_HF,_image_tag_and_HF_digest
--- PASS: TestGenerateDaemonSet/With_HF,_image_tag_and_HF_digest (0.00s)
=== RUN   TestGenerateDaemonSet/With_HF,_image_digest_overrides_tag
--- PASS: TestGenerateDaemonSet/With_HF,_image_digest_overrides_tag (0.00s)
=== RUN   TestGenerateDaemonSet/With_HF,_digests_overrides_tags
--- PASS: TestGenerateDaemonSet/With_HF,_digests_overrides_tags (0.00s)
--- PASS: TestGenerateDaemonSet (0.01s)
PASS
```

