### PR TITLE
Use splunk-hec-token for auth if present

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -4,6 +4,6 @@ const (
 	OperatorName      string = "splunk-forwarder-operator"
 	OperatorNamespace string = "openshift-splunk-forwarder-operator"
 
-	SplunkAuthSecretName     string = "splunk-auth" // #nosec G101 -- This is a false positive
-	SplunkHECTokenSecretName string = "splunk-hec-token"
+	SplunkAuthSecretName     string = "splunk-auth"      // #nosec G101 -- This is a false positive
+	SplunkHECTokenSecretName string = "splunk-hec-token" // #nosec G101 -- This is a false positive
 )

--- a/config/config.go
+++ b/config/config.go
@@ -4,5 +4,6 @@ const (
 	OperatorName      string = "splunk-forwarder-operator"
 	OperatorNamespace string = "openshift-splunk-forwarder-operator"
 
-	SplunkAuthSecretName string = "splunk-auth" // #nosec G101 -- This is a false positive
+	SplunkAuthSecretName     string = "splunk-auth" // #nosec G101 -- This is a false positive
+	SplunkHECTokenSecretName string = "splunk-hec-token"
 )

--- a/controllers/secret/secret_controller.go
+++ b/controllers/secret/secret_controller.go
@@ -73,7 +73,7 @@ func (r *SecretReconciler) Reconcile(ctx context.Context, request reconcile.Requ
 	listOpts := []client.ListOption{
 		client.InNamespace(request.Namespace),
 	}
-	err := r.Client.List(context.TODO(), sfCrds, listOpts...)
+	err := r.Client.List(ctx, sfCrds, listOpts...)
 	// Error getting CR
 	if err != nil {
 		return reconcile.Result{}, err
@@ -91,7 +91,7 @@ func (r *SecretReconciler) Reconcile(ctx context.Context, request reconcile.Requ
 	reqLogger := log.WithValues("Request.Namespace", request.Namespace, "Request.Name", request.Name)
 
 	secret := &corev1.Secret{}
-	err = r.Client.Get(context.TODO(), request.NamespacedName, secret)
+	err = r.Client.Get(ctx, request.NamespacedName, secret)
 	if err != nil {
 		if errors.IsNotFound(err) && request.Name == config.SplunkAuthSecretName {
 			reqLogger.Info("Legacy Splunk Auth Secret was deleted, not restarting DaemonSet")
@@ -101,7 +101,7 @@ func (r *SecretReconciler) Reconcile(ctx context.Context, request reconcile.Requ
 	}
 
 	currentDaemonSet := &appsv1.DaemonSet{}
-	err = r.Client.Get(context.TODO(), types.NamespacedName{Name: sfCrd.Name + "-ds", Namespace: secret.Namespace}, currentDaemonSet)
+	err = r.Client.Get(ctx, types.NamespacedName{Name: sfCrd.Name + "-ds", Namespace: secret.Namespace}, currentDaemonSet)
 	if err != nil {
 		if !errors.IsNotFound(err) {
 			return reconcile.Result{}, err
@@ -133,13 +133,13 @@ func (r *SecretReconciler) Reconcile(ctx context.Context, request reconcile.Requ
 		return reconcile.Result{}, err
 	}
 
-	err = r.Client.Delete(context.TODO(), currentDaemonSet)
+	err = r.Client.Delete(ctx, currentDaemonSet)
 	if err != nil {
 		return reconcile.Result{}, err
 	}
 
 	reqLogger.Info("Creating a new DaemonSet", "DaemonSet.Namespace", newDaemonSet.Namespace, "DaemonSet.Name", newDaemonSet.Name)
-	err = r.Client.Create(context.TODO(), newDaemonSet)
+	err = r.Client.Create(ctx, newDaemonSet)
 	if err != nil {
 		return reconcile.Result{}, err
 	}

--- a/controllers/secret/secret_controller.go
+++ b/controllers/secret/secret_controller.go
@@ -93,7 +93,7 @@ func (r *SecretReconciler) Reconcile(ctx context.Context, request reconcile.Requ
 	secret := &corev1.Secret{}
 	err = r.Client.Get(context.TODO(), request.NamespacedName, secret)
 	if err != nil {
-		if errors.IsNotFound(err) {
+		if errors.IsNotFound(err) && request.Name == config.SplunkAuthSecretName {
 			reqLogger.Error(err, "Splunk Auth Secret was deleted, recreate it or delete the CRD, not restarting DaemonSet")
 			return reconcile.Result{}, nil
 		}

--- a/controllers/secret/secret_controller.go
+++ b/controllers/secret/secret_controller.go
@@ -27,12 +27,9 @@ var log = logf.Log.WithName("controller_secret")
 // mySecretPredicate filters out any events not related to our Secret.
 func mySecretPredicate() predicate.Predicate {
 	return predicate.Funcs{
-		CreateFunc: func(e event.CreateEvent) bool { return passes(e.Object) },
-		DeleteFunc: func(e event.DeleteEvent) bool { return passes(e.Object) },
-		// UpdateFunc passes if *either* the new or old object is one we care about.
-		UpdateFunc: func(e event.UpdateEvent) bool {
-			return passes(e.ObjectOld) || passes(e.ObjectNew)
-		},
+		CreateFunc:  func(e event.CreateEvent) bool { return passes(e.Object) },
+		DeleteFunc:  func(e event.DeleteEvent) bool { return e.Object.GetName() == config.SplunkHECTokenSecretName },
+		UpdateFunc:  func(e event.UpdateEvent) bool { return passes(e.ObjectNew) },
 		GenericFunc: func(e event.GenericEvent) bool { return passes(e.Object) },
 	}
 }

--- a/controllers/secret/secret_controller.go
+++ b/controllers/secret/secret_controller.go
@@ -94,7 +94,7 @@ func (r *SecretReconciler) Reconcile(ctx context.Context, request reconcile.Requ
 	err = r.Client.Get(context.TODO(), request.NamespacedName, secret)
 	if err != nil {
 		if errors.IsNotFound(err) && request.Name == config.SplunkAuthSecretName {
-			reqLogger.Error(err, "Splunk Auth Secret was deleted, recreate it or delete the CRD, not restarting DaemonSet")
+			reqLogger.Info("Legacy Splunk Auth Secret was deleted, not restarting DaemonSet")
 			return reconcile.Result{}, nil
 		}
 		return reconcile.Result{}, err

--- a/controllers/secret/secret_controller_test.go
+++ b/controllers/secret/secret_controller_test.go
@@ -113,22 +113,6 @@ func TestReconcileSecret_Reconcile(t *testing.T) {
 			localObjects: []runtime.Object{},
 		},
 		{
-			name: "Invalid Secret Name",
-			args: args{
-				request: reconcile.Request{
-					NamespacedName: types.NamespacedName{
-						Name:      "invalid-secret-name",
-						Namespace: instanceNamespace,
-					},
-				},
-			},
-			want:    reconcile.Result{},
-			wantErr: false,
-			localObjects: []runtime.Object{
-				testSplunkForwarderCR(),
-			},
-		},
-		{
 			name: "No secret",
 			args: args{
 				request: reconcile.Request{

--- a/controllers/secret/secret_controller_test.go
+++ b/controllers/secret/secret_controller_test.go
@@ -62,6 +62,19 @@ func testSplunkForwarderSecret() *corev1.Secret {
 	return ret
 }
 
+func testSplunkForwarderHECSecret() *corev1.Secret {
+	ret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      config.SplunkHECTokenSecretName,
+			Namespace: instanceNamespace,
+			CreationTimestamp: metav1.Time{
+				Time: time.Now(),
+			},
+		},
+	}
+	return ret
+}
+
 func testSplunkForwarderDS() *appsv1.DaemonSet {
 	ret := &appsv1.DaemonSet{
 		ObjectMeta: metav1.ObjectMeta{
@@ -164,6 +177,25 @@ func TestReconcileSecret_Reconcile(t *testing.T) {
 				testSplunkForwarderCR(),
 				testSplunkForwarderSecret(),
 				testSplunkForwarderDS(),
+			},
+		},
+		{
+			name: "HEC Secret",
+			args: args{
+				request: reconcile.Request{
+					NamespacedName: types.NamespacedName{
+						Name:      config.SplunkAuthSecretName,
+						Namespace: instanceNamespace,
+					},
+				},
+			},
+			want:    reconcile.Result{},
+			wantErr: false,
+			localObjects: []runtime.Object{
+				testSplunkForwarderCR(),
+				testSplunkForwarderSecret(),
+				testSplunkForwarderDS(),
+				testSplunkForwarderHECSecret(),
 			},
 		},
 	}

--- a/controllers/secret/secret_controller_test.go
+++ b/controllers/secret/secret_controller_test.go
@@ -190,7 +190,7 @@ func TestReconcileSecret_Reconcile(t *testing.T) {
 				Client: fakeClient,
 				Scheme: scheme.Scheme,
 			}
-			got, err := r.Reconcile(context.TODO(), tt.args.request)
+			got, err := r.Reconcile(context.Background(), tt.args.request)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("SecretReconciler.Reconcile() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/controllers/splunkforwarder/splunkforwarder_controller.go
+++ b/controllers/splunkforwarder/splunkforwarder_controller.go
@@ -141,12 +141,10 @@ func (r *SplunkForwarderReconciler) Reconcile(ctx context.Context, request ctrl.
 	useHECToken := false
 	hecToken := &corev1.Secret{}
 	err = r.Client.Get(ctx, types.NamespacedName{Name: config.SplunkHECTokenSecretName, Namespace: request.Namespace}, hecToken)
-	if err != nil {
-		if errors.IsNotFound(err) {
-			r.ReqLogger.Info("HTTP Event Collector token not present, using mTLS authentication")
-		} else {
-			return reconcile.Result{}, err
-		}
+	if errors.IsNotFound(err) {
+		r.ReqLogger.Info("HTTP Event Collector token not present, using mTLS authentication")
+	} else if err != nil {
+		return reconcile.Result{}, err
 	} else {
 		r.ReqLogger.Info("HTTP Event Collector token found, using HEC mode for Splunk Universal Forwarder")
 		useHECToken = true

--- a/controllers/splunkforwarder/splunkforwarder_controller.go
+++ b/controllers/splunkforwarder/splunkforwarder_controller.go
@@ -138,8 +138,22 @@ func (r *SplunkForwarderReconciler) Reconcile(ctx context.Context, request ctrl.
 		}
 	}
 
+	useHECToken := false
+	hecToken := &corev1.Secret{}
+	err = r.Client.Get(ctx, types.NamespacedName{Name: config.SplunkHECTokenSecretName, Namespace: request.Namespace}, hecToken)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			r.ReqLogger.Info("HTTP Event Collector token not present, using mTLS authentication")
+		} else {
+			return reconcile.Result{}, err
+		}
+	} else {
+		r.ReqLogger.Info("HTTP Event Collector token found, using HEC mode for Splunk Universal Forwarder")
+		useHECToken = true
+	}
+
 	// DaemonSet
-	daemonSet := kube.GenerateDaemonSet(instance)
+	daemonSet := kube.GenerateDaemonSet(instance, useHECToken)
 	// Set SplunkForwarder instance as the owner and controller
 	if err := controllerutil.SetControllerReference(instance, daemonSet, r.Scheme); err != nil {
 		return reconcile.Result{}, err

--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -1419,3 +1419,109 @@ objects:
         - apiGroups: [""]
           resources: ["services", "endpoints", "pods", "servicemonitors"]
           verbs: ["get", "list", "watch"]
+
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    name: splunk-hec-token-sss-stg
+    namespace: splunk-forwarder-operator
+  spec:
+    clusterDeploymentSelector:
+      matchExpressions:
+        - key: api.openshift.com/managed
+          operator: In
+          values:
+            - "true"
+        - key: ext-hypershift.openshift.io/cluster-type
+          operator: NotIn
+          values:
+            - "management-cluster"
+        - key: api.openshift.com/environment
+          operator: In
+          values:
+            - "staging"
+        - key: api.openshift.com/noalerts
+          operator: NotIn
+          values:
+            - "true"
+        - key: ext-managed.openshift.io/noalerts
+          operator: NotIn
+          values:
+            - "true"
+        - key: api.openshift.com/legal-entity-id
+          operator: NotIn
+          values: ${{ALERTS_SKIP_LEGALENTITY_IDS}}
+        - key: hive.openshift.io/cluster-region
+          operator: NotIn
+          values:
+            - "cn-north-1"
+            - "cn-northwest-1"
+        - key: api.openshift.com/fedramp
+          operator: NotIn
+          values:
+            - "true"
+        - key: ext-managed.openshift.io/splunk-use-http
+          operator: In
+          values:
+            - "true"
+    resourceApplyMode: Sync
+    secretMappings:
+    - sourceRef:
+        name: splunk-hec-token-stg
+        namespace: splunk-forwarder-operator
+      targetRef:
+        name: splunk-hec-token
+        namespace: openshift-security
+
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    name: splunk-hec-token-sss
+    namespace: splunk-forwarder-operator
+  spec:
+    clusterDeploymentSelector:
+      matchExpressions:
+        - key: api.openshift.com/managed
+          operator: In
+          values:
+            - "true"
+        - key: ext-hypershift.openshift.io/cluster-type
+          operator: NotIn
+          values:
+            - "management-cluster"
+        - key: api.openshift.com/environment
+          operator: In
+          values:
+            - "production"
+        - key: api.openshift.com/noalerts
+          operator: NotIn
+          values:
+            - "true"
+        - key: ext-managed.openshift.io/noalerts
+          operator: NotIn
+          values:
+            - "true"
+        - key: api.openshift.com/legal-entity-id
+          operator: NotIn
+          values: ${{ALERTS_SKIP_LEGALENTITY_IDS}}
+        - key: hive.openshift.io/cluster-region
+          operator: NotIn
+          values:
+            - "cn-north-1"
+            - "cn-northwest-1"
+        - key: api.openshift.com/fedramp
+          operator: NotIn
+          values:
+            - "true"
+        - key: ext-managed.openshift.io/splunk-use-http
+          operator: In
+          values:
+            - "true"
+    resourceApplyMode: Sync
+    secretMappings:
+    - sourceRef:
+        name: splunk-hec-token-supportex-23207
+        namespace: splunk-forwarder-operator
+      targetRef:
+        name: splunk-hec-token
+        namespace: openshift-security

--- a/pkg/kube/daemonset.go
+++ b/pkg/kube/daemonset.go
@@ -23,7 +23,7 @@ func forwarderPullSpec(instance *sfv1alpha1.SplunkForwarder) string {
 }
 
 // GenerateDaemonSet returns a daemonset that can be created with the oc client
-func GenerateDaemonSet(instance *sfv1alpha1.SplunkForwarder) *appsv1.DaemonSet {
+func GenerateDaemonSet(instance *sfv1alpha1.SplunkForwarder, useHECToken bool) *appsv1.DaemonSet {
 
 	var runAsUID int64 = 0
 	var isPrivContainer bool = true
@@ -50,9 +50,9 @@ func GenerateDaemonSet(instance *sfv1alpha1.SplunkForwarder) *appsv1.DaemonSet {
 	var volumes []corev1.Volume
 
 	if instance.Spec.UseHeavyForwarder {
-		volumes = GetVolumes(true, false, instance.Name)
+		volumes = GetVolumes(true, false, useHECToken, instance.Name)
 	} else {
-		volumes = GetVolumes(true, true, instance.Name)
+		volumes = GetVolumes(true, true, useHECToken, instance.Name)
 	}
 
 	var priority int32 = 2000001000
@@ -113,7 +113,7 @@ func GenerateDaemonSet(instance *sfv1alpha1.SplunkForwarder) *appsv1.DaemonSet {
 
 							Env: envVars,
 
-							VolumeMounts: GetVolumeMounts(instance),
+							VolumeMounts: GetVolumeMounts(instance, useHECToken),
 
 							SecurityContext: &corev1.SecurityContext{
 								Privileged: &isPrivContainer,

--- a/pkg/kube/daemonset.go
+++ b/pkg/kube/daemonset.go
@@ -86,7 +86,7 @@ func GenerateDaemonSet(instance *sfv1alpha1.SplunkForwarder, useHECToken bool) *
 					PriorityClassName: "system-node-critical",
 					Priority:          &priority,
 					NodeSelector: map[string]string{
-						"beta.kubernetes.io/os": "linux",
+						"kubernetes.io/os": "linux",
 					},
 
 					ServiceAccountName: "default",

--- a/pkg/kube/daemonset_test.go
+++ b/pkg/kube/daemonset_test.go
@@ -95,7 +95,7 @@ func expectedDaemonSet(instance *sfv1alpha1.SplunkForwarder) *appsv1.DaemonSet {
 								},
 							},
 
-							VolumeMounts: GetVolumeMounts(instance),
+							VolumeMounts: GetVolumeMounts(instance, false),
 
 							SecurityContext: &corev1.SecurityContext{
 								Privileged: &expectedIsPrivContainer,
@@ -103,7 +103,7 @@ func expectedDaemonSet(instance *sfv1alpha1.SplunkForwarder) *appsv1.DaemonSet {
 							},
 						},
 					},
-					Volumes: GetVolumes(true, useVolumeSecret, instanceName),
+					Volumes: GetVolumes(true, useVolumeSecret, false, instanceName),
 				},
 			},
 		},
@@ -112,8 +112,9 @@ func expectedDaemonSet(instance *sfv1alpha1.SplunkForwarder) *appsv1.DaemonSet {
 
 func TestGenerateDaemonSet(t *testing.T) {
 	tests := []struct {
-		name     string
-		instance *sfv1alpha1.SplunkForwarder
+		name        string
+		instance    *sfv1alpha1.SplunkForwarder
+		useHECToken bool
 	}{
 		// TODO: The following configurations should be invalid and produce a predictable error:
 		// - splunkForwarderInstance(any, false, false, any)
@@ -181,7 +182,7 @@ func TestGenerateDaemonSet(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			expected := expectedDaemonSet(tt.instance)
-			actual := GenerateDaemonSet(tt.instance)
+			actual := GenerateDaemonSet(tt.instance, tt.useHECToken)
 			DeepEqualWithDiff(t, expected, actual)
 		})
 	}

--- a/pkg/kube/daemonset_test.go
+++ b/pkg/kube/daemonset_test.go
@@ -56,7 +56,7 @@ func expectedDaemonSet(instance *sfv1alpha1.SplunkForwarder) *appsv1.DaemonSet {
 					PriorityClassName: expectedPriorityClassName,
 					Priority:          &expectedPriority,
 					NodeSelector: map[string]string{
-						"beta.kubernetes.io/os": "linux",
+						"kubernetes.io/os": "linux",
 					},
 
 					ServiceAccountName: "default",

--- a/pkg/kube/deployment.go
+++ b/pkg/kube/deployment.go
@@ -44,6 +44,7 @@ func GenerateDeployment(instance *sfv1alpha1.SplunkForwarder) *appsv1.Deployment
 
 	var runAsUserID int64 = 1000
 	podSecurityContext := corev1.PodSecurityContext{RunAsUser: &runAsUserID}
+	useHECToken := false // never using HEC for heavy forwarder deployments
 
 	return &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
@@ -108,7 +109,7 @@ func GenerateDeployment(instance *sfv1alpha1.SplunkForwarder) *appsv1.Deployment
 							VolumeMounts: GetHeavyForwarderVolumeMounts(instance),
 						},
 					},
-					Volumes:         GetVolumes(false, true, instance.Name),
+					Volumes:         GetVolumes(false, true, useHECToken, instance.Name),
 					SecurityContext: &podSecurityContext,
 				},
 			},

--- a/pkg/kube/deployment_test.go
+++ b/pkg/kube/deployment_test.go
@@ -89,7 +89,7 @@ func expectedDeployment(instance *sfv1alpha1.SplunkForwarder) *appsv1.Deployment
 							VolumeMounts: GetHeavyForwarderVolumeMounts(instance),
 						},
 					},
-					Volumes: GetVolumes(false, true, "test"),
+					Volumes: GetVolumes(false, true, false, "test"),
 					SecurityContext: &corev1.PodSecurityContext{
 						RunAsUser: &expectedRunAsUserID,
 					},

--- a/pkg/kube/fixtures.go
+++ b/pkg/kube/fixtures.go
@@ -57,6 +57,7 @@ func splunkForwarderInstance(useHeavy, useTag, useDigest, useHFDigest bool) *sfv
 // DoDiff deep-compares two `runtime.Object`s and fails the `t`est with a useful message (showing
 // the diff) if they differ.
 func DeepEqualWithDiff(t *testing.T, expected, actual runtime.Object) {
+	t.Helper()
 	diff := cmp.Diff(expected, actual)
 	if diff != "" {
 		t.Fatal("Objects differ: -expected, +actual\n", diff)

--- a/pkg/kube/volumemounts.go
+++ b/pkg/kube/volumemounts.go
@@ -14,7 +14,7 @@ func GetVolumeMounts(instance *sfv1alpha1.SplunkForwarder, useHECToken bool) []c
 	volumeMounts := []corev1.VolumeMount{}
 	if useHECToken {
 		hecConfigMount := corev1.VolumeMount{
-			Name:      config.SplunkHECTokenSecretName,
+			Name:      "splunk-config",
 			MountPath: "/opt/splunkforwarder/etc/local",
 		}
 		volumeMounts = append(volumeMounts, hecConfigMount)
@@ -100,6 +100,19 @@ func GetHeavyForwarderVolumeMounts(instance *sfv1alpha1.SplunkForwarder) []corev
 		{
 			Name:      "splunk-state",
 			MountPath: "/opt/splunk/var/lib",
+		},
+	}
+}
+
+func getInitVolumeMounts() []corev1.VolumeMount {
+	return []corev1.VolumeMount{
+		{
+			Name:      config.SplunkHECTokenSecretName,
+			MountPath: "/tmp/splunk-hec-token",
+		},
+		{
+			Name:      "splunk-config",
+			MountPath: "/tmp/splunk-config",
 		},
 	}
 }

--- a/pkg/kube/volumemounts.go
+++ b/pkg/kube/volumemounts.go
@@ -15,7 +15,7 @@ func GetVolumeMounts(instance *sfv1alpha1.SplunkForwarder, useHECToken bool) []c
 	if useHECToken {
 		hecConfigMount := corev1.VolumeMount{
 			Name:      "splunk-config",
-			MountPath: "/opt/splunkforwarder/etc/local",
+			MountPath: "/opt/splunkforwarder/etc/system/local",
 		}
 		volumeMounts = append(volumeMounts, hecConfigMount)
 	} else {

--- a/pkg/kube/volumemounts_test.go
+++ b/pkg/kube/volumemounts_test.go
@@ -126,7 +126,7 @@ func TestGetVolumeMounts(t *testing.T) {
 			},
 			want: []corev1.VolumeMount{
 				{
-					Name:      config.SplunkHECTokenSecretName,
+					Name:      "splunk-config",
 					MountPath: "/opt/splunkforwarder/etc/local",
 				},
 				{

--- a/pkg/kube/volumemounts_test.go
+++ b/pkg/kube/volumemounts_test.go
@@ -127,7 +127,7 @@ func TestGetVolumeMounts(t *testing.T) {
 			want: []corev1.VolumeMount{
 				{
 					Name:      "splunk-config",
-					MountPath: "/opt/splunkforwarder/etc/local",
+					MountPath: "/opt/splunkforwarder/etc/system/local",
 				},
 				{
 					Name:      "osd-monitored-logs-local",

--- a/pkg/kube/volumes.go
+++ b/pkg/kube/volumes.go
@@ -70,15 +70,23 @@ func GetVolumes(mountHost, mountSecret, mountHECToken bool, instanceName string)
 	}
 
 	if mountHECToken {
-		volumes = append(volumes,
-			corev1.Volume{
+		hecVolumes := []corev1.Volume{
+			{
 				Name: config.SplunkHECTokenSecretName,
 				VolumeSource: corev1.VolumeSource{
 					Secret: &corev1.SecretVolumeSource{
 						SecretName: config.SplunkHECTokenSecretName,
 					},
 				},
-			})
+			},
+			{
+				Name: "splunk-config",
+				VolumeSource: corev1.VolumeSource{
+					EmptyDir: &corev1.EmptyDirVolumeSource{},
+				},
+			},
+		}
+		volumes = append(volumes, hecVolumes...)
 	} else if mountSecret {
 		volumes = append(volumes,
 			corev1.Volume{

--- a/pkg/kube/volumes.go
+++ b/pkg/kube/volumes.go
@@ -7,7 +7,7 @@ import (
 
 // GetVolumes Returns an array of corev1.Volumes we want to attach
 // It contains configmaps, secrets, and the host mount
-func GetVolumes(mountHost bool, mountSecret bool, instanceName string) []corev1.Volume {
+func GetVolumes(mountHost, mountSecret, mountHECToken bool, instanceName string) []corev1.Volume {
 	var hostPathDirectoryTypeForPtr = corev1.HostPathDirectory
 
 	volumes := []corev1.Volume{
@@ -69,7 +69,17 @@ func GetVolumes(mountHost bool, mountSecret bool, instanceName string) []corev1.
 			})
 	}
 
-	if mountSecret {
+	if mountHECToken {
+		volumes = append(volumes,
+			corev1.Volume{
+				Name: config.SplunkHECTokenSecretName,
+				VolumeSource: corev1.VolumeSource{
+					Secret: &corev1.SecretVolumeSource{
+						SecretName: config.SplunkHECTokenSecretName,
+					},
+				},
+			})
+	} else if mountSecret {
 		volumes = append(volumes,
 			corev1.Volume{
 				Name: config.SplunkAuthSecretName,

--- a/pkg/kube/volumes_test.go
+++ b/pkg/kube/volumes_test.go
@@ -12,9 +12,10 @@ func TestGetVolumes(t *testing.T) {
 	var hostPathDirectoryTypeForPtr = corev1.HostPathDirectory
 
 	type args struct {
-		mountHost    bool
-		mountSecret  bool
-		instanceName string
+		mountHost     bool
+		mountSecret   bool
+		mountHECToken bool
+		instanceName  string
 	}
 	tests := []struct {
 		name string
@@ -251,10 +252,67 @@ func TestGetVolumes(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "HEC token supersedes old secret",
+			args: args{
+				mountHost:     true,
+				mountSecret:   true,
+				mountHECToken: true,
+				instanceName:  "test",
+			},
+			want: []corev1.Volume{
+				{
+					Name: "osd-monitored-logs-local",
+					VolumeSource: corev1.VolumeSource{
+						ConfigMap: &corev1.ConfigMapVolumeSource{
+							LocalObjectReference: corev1.LocalObjectReference{
+								Name: "osd-monitored-logs-local",
+							},
+						},
+					},
+				},
+				{
+					Name: "osd-monitored-logs-metadata",
+					VolumeSource: corev1.VolumeSource{
+						ConfigMap: &corev1.ConfigMapVolumeSource{
+							LocalObjectReference: corev1.LocalObjectReference{
+								Name: "osd-monitored-logs-metadata",
+							},
+						},
+					},
+				},
+				{
+					Name: "splunk-state",
+					VolumeSource: corev1.VolumeSource{
+						HostPath: &corev1.HostPathVolumeSource{
+							Path: "/var/lib/misc",
+							Type: &hostPathDirectoryTypeForPtr,
+						},
+					},
+				},
+				{
+					Name: "host",
+					VolumeSource: corev1.VolumeSource{
+						HostPath: &corev1.HostPathVolumeSource{
+							Path: "/",
+							Type: &hostPathDirectoryTypeForPtr,
+						},
+					},
+				},
+				{
+					Name: config.SplunkHECTokenSecretName,
+					VolumeSource: corev1.VolumeSource{
+						Secret: &corev1.SecretVolumeSource{
+							SecretName: config.SplunkHECTokenSecretName,
+						},
+					},
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := GetVolumes(tt.args.mountHost, tt.args.mountSecret, tt.args.instanceName); !reflect.DeepEqual(got, tt.want) {
+			if got := GetVolumes(tt.args.mountHost, tt.args.mountSecret, tt.args.mountHECToken, tt.args.instanceName); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("GetVolumes() = %v, want %v", got, tt.want)
 			}
 		})

--- a/pkg/kube/volumes_test.go
+++ b/pkg/kube/volumes_test.go
@@ -307,6 +307,12 @@ func TestGetVolumes(t *testing.T) {
 						},
 					},
 				},
+				{
+					Name: "splunk-config",
+					VolumeSource: corev1.VolumeSource{
+						EmptyDir: &corev1.EmptyDirVolumeSource{},
+					},
+				},
 			},
 		},
 	}


### PR DESCRIPTION
The splunkforwarder-ds DaemonSet will use the splunk-hec-token secret if it is present for authentication to the Splunk instance. This will cause the Splunk Universal Forwarder to switch to forwarding events over HTTP instead of sending raw TCP events, which will allow traffic to Splunk to be routed through HTTP proxies.