### PR TITLE
SDE-4573: enable OLM skip range

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -6,4 +6,6 @@ const (
 
 	SplunkAuthSecretName     string = "splunk-auth"      // #nosec G101 -- This is a false positive
 	SplunkHECTokenSecretName string = "splunk-hec-token" // #nosec G101 -- This is a false positive
+
+	EnableOLMSkipRange = "true"
 )


### PR DESCRIPTION
Configure boilerplate to generate an OLM bundle with a skip range
pointing to the latest version. This will allow OLM to upgrade past
broken replaces chains in which versions get abadoned without a path
forward. The new OLM bundle will contain a single version, referencing
the latest build with a `skipRange` to the version.

```
$ opm render -o yaml quay.io/bpratt/splunk-forwarder-operator-registry:production-latest
WARN[0003] DEPRECATION NOTICE:
Sqlite-based catalogs and their related subcommands are deprecated. Support for
them will be removed in a future release. Please migrate your catalog workflows
to the new file-based catalog format.
---
defaultChannel: production
name: splunk-forwarder-operator
schema: olm.package
---
entries:
- name: splunk-forwarder-operator.v0.1.567-gbd4c5eb
  skipRange: '>=0.0.1 <0.1.567-gbd4c5eb'
name: production
package: splunk-forwarder-operator
schema: olm.channel
---
image: ""
name: splunk-forwarder-operator.v0.1.567-gbd4c5eb
package: splunk-forwarder-operator
properties:
- type: olm.gvk
...
```

addon-operator and must-gather-operator are both configured similarly in
production currently.

https://v0-18-z.olm.operatorframework.io/docs/concepts/olm-architecture/operator-catalog/creating-an-update-graph/#skiprange

https://github.com/openshift/boilerplate/tree/8563add3b7f509de3b49ba04863d2708d965b489/boilerplate/openshift/golang-osd-operator#olm-skiprange

Signed-off-by: Brady Pratt <bpratt@redhat.com>

https://issues.redhat.com/browse/SDE-4573
