### PR TITLE
[OSD-27932] sync HEC token to all clusters

### DIFF
--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -1406,7 +1406,7 @@ objects:
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:
-    name: splunk-hec-token-fips-stg
+    name: splunk-hec-token-stg
     namespace: splunk-forwarder-operator
   spec:
     clusterDeploymentSelector:
@@ -1443,10 +1443,6 @@ objects:
           operator: NotIn
           values:
             - "true"
-        - key: ext-managed.openshift.io/fips-enabled-itn-2025-00017
-          operator: In
-          values:
-            - "true"
     resourceApplyMode: Sync
     secretMappings:
     - sourceRef:
@@ -1459,60 +1455,7 @@ objects:
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:
-    name: splunk-hec-token-sss-stg
-    namespace: splunk-forwarder-operator
-  spec:
-    clusterDeploymentSelector:
-      matchExpressions:
-        - key: api.openshift.com/managed
-          operator: In
-          values:
-            - "true"
-        - key: ext-hypershift.openshift.io/cluster-type
-          operator: NotIn
-          values:
-            - "management-cluster"
-        - key: api.openshift.com/environment
-          operator: In
-          values:
-            - "staging"
-        - key: api.openshift.com/noalerts
-          operator: NotIn
-          values:
-            - "true"
-        - key: ext-managed.openshift.io/noalerts
-          operator: NotIn
-          values:
-            - "true"
-        - key: api.openshift.com/legal-entity-id
-          operator: NotIn
-          values: ${{ALERTS_SKIP_LEGALENTITY_IDS}}
-        - key: hive.openshift.io/cluster-region
-          operator: NotIn
-          values:
-            - "cn-north-1"
-            - "cn-northwest-1"
-        - key: api.openshift.com/fedramp
-          operator: NotIn
-          values:
-            - "true"
-        - key: ext-managed.openshift.io/splunk-use-http
-          operator: In
-          values:
-            - "true"
-    resourceApplyMode: Sync
-    secretMappings:
-    - sourceRef:
-        name: splunk-hec-token-stg
-        namespace: splunk-forwarder-operator
-      targetRef:
-        name: splunk-hec-token
-        namespace: openshift-security
-
-- apiVersion: hive.openshift.io/v1
-  kind: SelectorSyncSet
-  metadata:
-    name: splunk-hec-token-sss
+    name: splunk-hec-token
     namespace: splunk-forwarder-operator
   spec:
     clusterDeploymentSelector:
@@ -1549,10 +1492,6 @@ objects:
           operator: NotIn
           values:
             - "true"
-        - key: ext-managed.openshift.io/splunk-use-http
-          operator: In
-          values:
-            - "true"
     resourceApplyMode: Sync
     secretMappings:
     - sourceRef:
@@ -1561,57 +1500,3 @@ objects:
       targetRef:
         name: splunk-hec-token
         namespace: openshift-security
-
-- apiVersion: hive.openshift.io/v1
-  kind: SelectorSyncSet
-  metadata:
-    name: splunk-hec-token-fips
-    namespace: splunk-forwarder-operator
-  spec:
-    clusterDeploymentSelector:
-      matchExpressions:
-        - key: api.openshift.com/managed
-          operator: In
-          values:
-            - "true"
-        - key: ext-hypershift.openshift.io/cluster-type
-          operator: NotIn
-          values:
-            - "management-cluster"
-        - key: api.openshift.com/environment
-          operator: In
-          values:
-            - "production"
-        - key: api.openshift.com/noalerts
-          operator: NotIn
-          values:
-            - "true"
-        - key: ext-managed.openshift.io/noalerts
-          operator: NotIn
-          values:
-            - "true"
-        - key: api.openshift.com/legal-entity-id
-          operator: NotIn
-          values: ${{ALERTS_SKIP_LEGALENTITY_IDS}}
-        - key: hive.openshift.io/cluster-region
-          operator: NotIn
-          values:
-            - "cn-north-1"
-            - "cn-northwest-1"
-        - key: api.openshift.com/fedramp
-          operator: NotIn
-          values:
-            - "true"
-        - key: ext-managed.openshift.io/fips-enabled-itn-2025-00017
-          operator: In
-          values:
-            - "true"
-    resourceApplyMode: Sync
-    secretMappings:
-    - sourceRef:
-        name: splunk-hec-token-supportex-23207
-        namespace: splunk-forwarder-operator
-      targetRef:
-        name: splunk-hec-token
-        namespace: openshift-security
-


### PR DESCRIPTION
Since HEC token authentication takes priority over mTLS auth, this will mean the Splunk forwarder will switch over to HTTP mode for all OSD and ROSA Classic clusters. Until the work to create an operator to manage the token lifecycle is completed the clusters will be sharing a single HEC token for authentication, but that is the same state as the mTLS certificate so there is no added risk.