### PR TITLE
only run reconciliation on splunk secrets

### DIFF
--- a/controllers/secret/secret_controller.go
+++ b/controllers/secret/secret_controller.go
@@ -31,7 +31,7 @@ func mySecretPredicate() predicate.Predicate {
 		CreateFunc: func(e event.CreateEvent) bool { return passes(e.Object) },
 		DeleteFunc: func(e event.DeleteEvent) bool { return e.Object.GetName() == config.SplunkHECTokenSecretName },
 		UpdateFunc: func(e event.UpdateEvent) bool {
-			return dataChanged(e.ObjectOld.(*corev1.Secret), e.ObjectNew.(*corev1.Secret))
+			return passes(e.ObjectOld) && dataChanged(e.ObjectOld.(*corev1.Secret), e.ObjectNew.(*corev1.Secret))
 		},
 		GenericFunc: func(e event.GenericEvent) bool { return passes(e.Object) },
 	}


### PR DESCRIPTION
Due to how reconciliation works `e.ObjectOld` and `e.ObjectNew` will always have the same name, so we only need to check one of them.