### PR TITLE
Combine the create and delete tests into one to avoid dependencies between tests

### DIFF
--- a/test/e2e/splunk_forwarder_operator_tests.go
+++ b/test/e2e/splunk_forwarder_operator_tests.go
@@ -118,15 +118,11 @@ var _ = ginkgo.Describe("Splunk Forwarder Operator", ginkgo.Ordered, func() {
 
 	})
 
-	sf := makeMinimalSplunkforwarder(testsplunkforwarder)
-
-	ginkgo.It("admin should be able to create SplunkForwarders CR", func(ctx context.Context) {
+	ginkgo.It("admin should be able to create and delete SplunkForwarders CR", func(ctx context.Context) {
+		sf := makeMinimalSplunkforwarder(testsplunkforwarder)
 		err := k8s.WithNamespace(operatorNamespace).Create(ctx, &sf)
 		Expect(err).NotTo(HaveOccurred())
-	})
-
-	ginkgo.It("admin should be able to delete SplunkForwarders CR", func(ctx context.Context) {
-		err := k8s.Delete(ctx, &sf)
+		err = k8s.WithNamespace(operatorNamespace).Delete(ctx, &sf)
 		Expect(err).NotTo(HaveOccurred())
 	})
 


### PR DESCRIPTION
As part of the effort to stabilize the ROSA test suites, this ticket will help to stabilize the `splunk-forwarder-operator` suite by ensuring that there are no dependencies between individual tests.

Specifically, this will combine the separate tests that 1) create a splunkforwarder and 2) delete that created splunkforwarder into a single test.

[OSD-29465](https://issues.redhat.com//browse/OSD-29465)