### PR TITLE
Correcting the location of the backplane audit log

### DIFF
--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -745,7 +745,7 @@ objects:
               index: rh_osd_malware_scan
               whiteList: \.log$
               sourceType: openshift:debug
-            - path: /host/var/lib/kubelet/pods/*/volumes/kubernetes.io~*/pvc-*/backplane-audit.log
+            - path: /host/var/lib/kubelet/pods/*/volumes/kubernetes.io~*/pvc-*/mount/backplane-audit.log
               index: rh_osd_backplane_prod
               sourceType: _json
               whiteList: \.log$
@@ -849,7 +849,7 @@ objects:
           path: /host/var/log/auth.log
           sourceType: linux_audit
           whiteList: \.log$
-        - path: /host/var/lib/kubelet/pods/*/volumes/kubernetes.io~*/pvc-*/backplane-audit.log
+        - path: /host/var/lib/kubelet/pods/*/volumes/kubernetes.io~*/pvc-*/mount/backplane-audit.log
           index: rh_osd_backplane_prod
           sourceType: _json
           whiteList: \.log$


### PR DESCRIPTION
At some point the location of the audit log changed.  This PR will update to reflect the existing path.

Verification from the pod
```
find /host/var/lib/kubelet/pods/ -name "*.log"
/host/var/lib/kubelet/pods/55977b9c-ff3b-4d49-8493-d3d890a92d4b/volumes/kubernetes.io~csi/pvc-b279ab61-40e2-4dfa-aaef-3315d790cb16/mount/backplane-audit-2023-07-10T19-34-10.044.log
/host/var/lib/kubelet/pods/55977b9c-ff3b-4d49-8493-d3d890a92d4b/volumes/kubernetes.io~csi/pvc-b279ab61-40e2-4dfa-aaef-3315d790cb16/mount/backplane-audit-2023-10-12T21-42-56.643.log
/host/var/lib/kubelet/pods/55977b9c-ff3b-4d49-8493-d3d890a92d4b/volumes/kubernetes.io~csi/pvc-b279ab61-40e2-4dfa-aaef-3315d790cb16/mount/backplane-audit-2024-10-29T17-11-05.676.log
/host/var/lib/kubelet/pods/55977b9c-ff3b-4d49-8493-d3d890a92d4b/volumes/kubernetes.io~csi/pvc-b279ab61-40e2-4dfa-aaef-3315d790cb16/mount/backplane-audit-2024-04-15T19-29-56.045.log
/host/var/lib/kubelet/pods/55977b9c-ff3b-4d49-8493-d3d890a92d4b/volumes/kubernetes.io~csi/pvc-b279ab61-40e2-4dfa-aaef-3315d790cb16/mount/backplane-audit-2025-04-24T18-31-34.144.log
/host/var/lib/kubelet/pods/55977b9c-ff3b-4d49-8493-d3d890a92d4b/volumes/kubernetes.io~csi/pvc-b279ab61-40e2-4dfa-aaef-3315d790cb16/mount/backplane-audit-2025-01-15T20-12-44.226.log
/host/var/lib/kubelet/pods/55977b9c-ff3b-4d49-8493-d3d890a92d4b/volumes/kubernetes.io~csi/pvc-b279ab61-40e2-4dfa-aaef-3315d790cb16/mount/backplane-audit.log
```