### PR TITLE
bump build image to rhel9

### DIFF
--- a/build/Dockerfile.olm-registry
+++ b/build/Dockerfile.olm-registry
@@ -1,4 +1,4 @@
-FROM registry.redhat.io/openshift4/ose-operator-registry:v4.14 AS builder
+FROM registry.redhat.io/openshift4/ose-operator-registry-rhel9:v4.19 AS builder
 ARG SAAS_OPERATOR_DIR
 COPY ${SAAS_OPERATOR_DIR} manifests
 RUN initializer --permissive


### PR DESCRIPTION
Attempting to clear up FIPS errors by bumping the build image for the operator's OLM Registry container to a version based on RHEL9.
