### PR TITLE
Fix Compatibility Issue - Rollback to go-v1.24.4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/openshift/splunk-forwarder-operator
 
-go 1.24.6
+go 1.24.4
 
 require (
 	github.com/onsi/ginkgo/v2 v2.9.5


### PR DESCRIPTION
## Summary
This PR contains a Go version downgrade for build pipeline compatibility reasons.

### Changes Made
- **File Modified**: `go.mod`
- **Change**: Downgraded Go version from `1.24.6` to `1.24.4`

### Justification
The Go version has been downgraded from 1.24.6 to 1.24.4, due to:
- Compatibility issues with the current build environment

### Security
This does not impact the security fixes / mitigations of https://github.com/openshift/splunk-forwarder-operator/pull/375