### PR TITLE
Fixing PKO service account issue

### DIFF
--- a/deploy_pko/ClusterRoleBinding-splunk-forwarder-operator.yaml.gotmpl
+++ b/deploy_pko/ClusterRoleBinding-splunk-forwarder-operator.yaml.gotmpl
@@ -7,7 +7,7 @@ metadata:
     package-operator.run/collision-protection: IfNoController
 subjects:
 - kind: ServiceAccount
-  name: default
+  name: splunk-forwarder-operator
   namespace: {{ .config.namespace }}
 roleRef:
   kind: ClusterRole


### PR DESCRIPTION
The service account for PKO is set to default but should reflect the SA of the other files which is splunk-forwarder-operator