### PR TITLE
Add terminationMessagePolicy and required-scc annotation for OCP 4.21 conformance

### DIFF
--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -11,6 +11,8 @@ spec:
     metadata:
       labels:
         name: splunk-forwarder-operator
+      annotations:
+        openshift.io/required-scc: restricted-v2
     spec:
       serviceAccountName: splunk-forwarder-operator
       affinity:
@@ -43,3 +45,4 @@ spec:
                   fieldPath: metadata.name
             - name: OPERATOR_NAME
               value: "splunk-forwarder-operator"
+          terminationMessagePolicy: FallbackToLogsOnError

--- a/deploy_pko/.test-fixtures/default/Deployment-splunk-forwarder-operator.yaml
+++ b/deploy_pko/.test-fixtures/default/Deployment-splunk-forwarder-operator.yaml
@@ -15,6 +15,8 @@ spec:
     metadata:
       labels:
         name: splunk-forwarder-operator
+      annotations:
+        openshift.io/required-scc: restricted-v2
     spec:
       serviceAccountName: splunk-forwarder-operator
       affinity:
@@ -46,3 +48,4 @@ spec:
               fieldPath: metadata.name
         - name: OPERATOR_NAME
           value: splunk-forwarder-operator
+        terminationMessagePolicy: FallbackToLogsOnError

--- a/deploy_pko/Deployment-splunk-forwarder-operator.yaml.gotmpl
+++ b/deploy_pko/Deployment-splunk-forwarder-operator.yaml.gotmpl
@@ -15,6 +15,8 @@ spec:
     metadata:
       labels:
         name: splunk-forwarder-operator
+      annotations:
+        openshift.io/required-scc: restricted-v2
     spec:
       serviceAccountName: splunk-forwarder-operator
       affinity:
@@ -46,3 +48,4 @@ spec:
               fieldPath: metadata.name
         - name: OPERATOR_NAME
           value: splunk-forwarder-operator
+        terminationMessagePolicy: FallbackToLogsOnError


### PR DESCRIPTION
## Summary

- Adds `terminationMessagePolicy: FallbackToLogsOnError` to the operator container spec in both OLM (`deploy/`) and PKO (`deploy_pko/`) deployment manifests
- Adds `openshift.io/required-scc: restricted-v2` annotation to pod template metadata in both deployment manifests

These are required for OCP 4.21 conformance. The `terminationMessagePolicy` ensures container termination messages capture log output on error, and the `required-scc` annotation explicitly declares the security context constraint the pod needs.

## Test plan

- [ ] Verify YAML is valid and properly indented
- [ ] Deploy to integration and confirm operator starts correctly
- [ ] Confirm `terminationMessagePolicy` appears in pod spec via `oc get pod -o yaml`
- [ ] Confirm `required-scc` annotation appears in pod metadata

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enforced OpenShift “restricted-v2” security constraints for the operator pods to better align with required runtime permissions.
  * Updated pod termination behavior so termination messages fall back to container logs when errors occur, improving troubleshooting visibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->