### PR TITLE
Add nodes permissions to PKO ClusterRole

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -3,7 +3,7 @@ COPY . /go/src/github.com/openshift/splunk-forwarder-operator
 WORKDIR /go/src/github.com/openshift/splunk-forwarder-operator
 RUN make go-build
 
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7-1776104705
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7-1776645941
 ENV OPERATOR_PATH=/go/src/github.com/openshift/splunk-forwarder-operator \
     OPERATOR_BIN=splunk-forwarder-operator
 

--- a/build/Dockerfile.olm-registry
+++ b/build/Dockerfile.olm-registry
@@ -4,7 +4,7 @@ COPY ${SAAS_OPERATOR_DIR} manifests
 RUN initializer --permissive
 
 # ubi-micro does not work for clusters with fips enabled unless we make OpenSSL available
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7-1776104705
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7-1776645941
 
 COPY --from=builder /bin/registry-server /bin/registry-server
 COPY --from=builder /bin/grpc_health_probe /bin/grpc_health_probe

--- a/deploy_pko/.test-fixtures/default/ClusterRole-splunk-forwarder-operator.yaml
+++ b/deploy_pko/.test-fixtures/default/ClusterRole-splunk-forwarder-operator.yaml
@@ -25,6 +25,14 @@ rules:
   - create
   - delete
 - apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - apps
   resources:
   - daemonsets

--- a/deploy_pko/ClusterRole-splunk-forwarder-operator.yaml
+++ b/deploy_pko/ClusterRole-splunk-forwarder-operator.yaml
@@ -25,6 +25,14 @@ rules:
   - create
   - delete
 - apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - apps
   resources:
   - daemonsets


### PR DESCRIPTION
The operator needs to get/list/watch nodes at cluster scope for DaemonSet scheduling and node metadata. Without this permission, the operator fails with:

  'nodes "<node-name>" is forbidden: User "system:serviceaccount:openshift-splunk-forwarder-operator:splunk-forwarder-operator" cannot get resource "nodes" in API group "" at the cluster scope'

This permission exists in the OLM ClusterRole (via wildcard) but was missing from the PKO ClusterRole definition.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated cluster-level permissions to enable monitoring and access to node information across the cluster.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->