### PR TITLE
Update splunk-forwarder image references to Konflux-built location

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ The `image` and `imageDigest` are for the splunk-forwarder image.
 (The CRD supports `imageTag`, but this is deprecated in favor of `imageDigest`.)
 
 To use the current version, `10.2.0-d749cb17ea65-d12f202`, specify the following:
-- For [splunk-forwarder](https://quay.io/repository/app-sre/splunk-forwarder?tag=8.2.5-77015bc7a462-f4d16f7):
+- For [splunk-forwarder-images](https://quay.io/repository/redhat-services-prod/openshift/splunk-forwarder-images):
   ```yaml
   image: quay.io/redhat-services-prod/openshift/splunk-forwarder-images
   imageDigest: sha256:e400fcba1cccfa503e93127fd914a8b262857abdc72b0c6eade9b911ac9939ab

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ metadata:
   name: example-splunkforwarder
 spec:
   image: dockerimageurl
-  imageDigest: sha256:e400fcba1cccfa503e93127fd914a8b262857abdc72b0c6eade9b911ac9939ab
+  imageDigest: sha256:534d2dc94dcc28f99f7358a0a55683f0f6b93e23141e28073e81287e63353399
   splunkLicenseAccepted: true
   clusterID: optional-cluster-name
   splunkInputs:
@@ -56,7 +56,7 @@ To use the current version, `10.2.0-d749cb17ea65-d12f202`, specify the following
 - For [splunk-forwarder-images](https://quay.io/repository/redhat-services-prod/openshift/splunk-forwarder-images):
   ```yaml
   image: quay.io/redhat-services-prod/openshift/splunk-forwarder-images
-  imageDigest: sha256:e400fcba1cccfa503e93127fd914a8b262857abdc72b0c6eade9b911ac9939ab
+  imageDigest: sha256:534d2dc94dcc28f99f7358a0a55683f0f6b93e23141e28073e81287e63353399
   ```
 
 ## Upgrading Splunk Universal Forwarder

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ The `image` and `imageDigest` are for the splunk-forwarder image.
 To use the current version, `10.2.0-d749cb17ea65-d12f202`, specify the following:
 - For [splunk-forwarder](https://quay.io/repository/app-sre/splunk-forwarder?tag=8.2.5-77015bc7a462-f4d16f7):
   ```yaml
-  image: quay.io/app-sre/splunk-forwarder
+  image: quay.io/redhat-services-prod/openshift/splunk-forwarder-images
   imageDigest: sha256:e400fcba1cccfa503e93127fd914a8b262857abdc72b0c6eade9b911ac9939ab
   ```
 

--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -342,7 +342,7 @@ objects:
         name: splunkforwarder
         namespace: openshift-security
       spec:
-        image: quay.io/app-sre/splunk-forwarder
+        image: quay.io/redhat-services-prod/openshift/splunk-forwarder-images
         imageDigest: sha256:e400fcba1cccfa503e93127fd914a8b262857abdc72b0c6eade9b911ac9939ab
         splunkLicenseAccepted: true
         filters:
@@ -430,7 +430,7 @@ objects:
         name: splunkforwarder
         namespace: openshift-security
       spec:
-        image: quay.io/app-sre/splunk-forwarder
+        image: quay.io/redhat-services-prod/openshift/splunk-forwarder-images
         imageDigest: sha256:e400fcba1cccfa503e93127fd914a8b262857abdc72b0c6eade9b911ac9939ab
         splunkLicenseAccepted: true
         splunkInputs:
@@ -487,7 +487,7 @@ objects:
           name: splunkforwarder
           namespace: openshift-security
         spec:
-          image: quay.io/app-sre/splunk-forwarder
+          image: quay.io/redhat-services-prod/openshift/splunk-forwarder-images
           imageDigest: sha256:e400fcba1cccfa503e93127fd914a8b262857abdc72b0c6eade9b911ac9939ab
           splunkLicenseAccepted: true
           splunkInputs:
@@ -560,7 +560,7 @@ objects:
           name: splunkforwarder
           namespace: openshift-security
         spec:
-          image: quay.io/app-sre/splunk-forwarder
+          image: quay.io/redhat-services-prod/openshift/splunk-forwarder-images
           imageDigest: sha256:e400fcba1cccfa503e93127fd914a8b262857abdc72b0c6eade9b911ac9939ab
           splunkLicenseAccepted: true
           filters:
@@ -647,7 +647,7 @@ objects:
           name: splunkforwarder
           namespace: openshift-security
         spec:
-          image: quay.io/app-sre/splunk-forwarder
+          image: quay.io/redhat-services-prod/openshift/splunk-forwarder-images
           imageDigest: sha256:e400fcba1cccfa503e93127fd914a8b262857abdc72b0c6eade9b911ac9939ab
           splunkLicenseAccepted: true
           splunkInputs:
@@ -712,7 +712,7 @@ objects:
           name: splunkforwarder
           namespace: openshift-security
         spec:
-          image: quay.io/app-sre/splunk-forwarder
+          image: quay.io/redhat-services-prod/openshift/splunk-forwarder-images
           imageDigest: sha256:e400fcba1cccfa503e93127fd914a8b262857abdc72b0c6eade9b911ac9939ab
           splunkLicenseAccepted: true
           filters:
@@ -800,7 +800,7 @@ objects:
         name: splunkforwarder
         namespace: openshift-security
       spec:
-        image: quay.io/app-sre/splunk-forwarder
+        image: quay.io/redhat-services-prod/openshift/splunk-forwarder-images
         imageDigest: sha256:e400fcba1cccfa503e93127fd914a8b262857abdc72b0c6eade9b911ac9939ab
         splunkLicenseAccepted: true
         filters:
@@ -903,7 +903,7 @@ objects:
         name: splunkforwarder
         namespace: openshift-security
       spec:
-        image: quay.io/app-sre/splunk-forwarder
+        image: quay.io/redhat-services-prod/openshift/splunk-forwarder-images
         imageDigest: sha256:e400fcba1cccfa503e93127fd914a8b262857abdc72b0c6eade9b911ac9939ab
         splunkLicenseAccepted: true
         splunkInputs:

--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -343,7 +343,7 @@ objects:
         namespace: openshift-security
       spec:
         image: quay.io/redhat-services-prod/openshift/splunk-forwarder-images
-        imageDigest: sha256:e400fcba1cccfa503e93127fd914a8b262857abdc72b0c6eade9b911ac9939ab
+        imageDigest: sha256:534d2dc94dcc28f99f7358a0a55683f0f6b93e23141e28073e81287e63353399
         splunkLicenseAccepted: true
         filters:
         - name: ignore_serviceaccount_users
@@ -431,7 +431,7 @@ objects:
         namespace: openshift-security
       spec:
         image: quay.io/redhat-services-prod/openshift/splunk-forwarder-images
-        imageDigest: sha256:e400fcba1cccfa503e93127fd914a8b262857abdc72b0c6eade9b911ac9939ab
+        imageDigest: sha256:534d2dc94dcc28f99f7358a0a55683f0f6b93e23141e28073e81287e63353399
         splunkLicenseAccepted: true
         splunkInputs:
         - path: /host/var/log/pods/*_ip-*-*-*-*ec2internal-debug_*/container-*/*.log
@@ -488,7 +488,7 @@ objects:
           namespace: openshift-security
         spec:
           image: quay.io/redhat-services-prod/openshift/splunk-forwarder-images
-          imageDigest: sha256:e400fcba1cccfa503e93127fd914a8b262857abdc72b0c6eade9b911ac9939ab
+          imageDigest: sha256:534d2dc94dcc28f99f7358a0a55683f0f6b93e23141e28073e81287e63353399
           splunkLicenseAccepted: true
           splunkInputs:
             - path: /host/var/log/hypershift-osd-audit/*/audit.log
@@ -561,7 +561,7 @@ objects:
           namespace: openshift-security
         spec:
           image: quay.io/redhat-services-prod/openshift/splunk-forwarder-images
-          imageDigest: sha256:e400fcba1cccfa503e93127fd914a8b262857abdc72b0c6eade9b911ac9939ab
+          imageDigest: sha256:534d2dc94dcc28f99f7358a0a55683f0f6b93e23141e28073e81287e63353399
           splunkLicenseAccepted: true
           filters:
             - name: ignore_serviceaccount_users
@@ -648,7 +648,7 @@ objects:
           namespace: openshift-security
         spec:
           image: quay.io/redhat-services-prod/openshift/splunk-forwarder-images
-          imageDigest: sha256:e400fcba1cccfa503e93127fd914a8b262857abdc72b0c6eade9b911ac9939ab
+          imageDigest: sha256:534d2dc94dcc28f99f7358a0a55683f0f6b93e23141e28073e81287e63353399
           splunkLicenseAccepted: true
           splunkInputs:
             - path: /host/var/log/hypershift-osd-audit/*/audit.log
@@ -713,7 +713,7 @@ objects:
           namespace: openshift-security
         spec:
           image: quay.io/redhat-services-prod/openshift/splunk-forwarder-images
-          imageDigest: sha256:e400fcba1cccfa503e93127fd914a8b262857abdc72b0c6eade9b911ac9939ab
+          imageDigest: sha256:534d2dc94dcc28f99f7358a0a55683f0f6b93e23141e28073e81287e63353399
           splunkLicenseAccepted: true
           filters:
             - name: ignore_serviceaccount_users
@@ -801,7 +801,7 @@ objects:
         namespace: openshift-security
       spec:
         image: quay.io/redhat-services-prod/openshift/splunk-forwarder-images
-        imageDigest: sha256:e400fcba1cccfa503e93127fd914a8b262857abdc72b0c6eade9b911ac9939ab
+        imageDigest: sha256:534d2dc94dcc28f99f7358a0a55683f0f6b93e23141e28073e81287e63353399
         splunkLicenseAccepted: true
         filters:
         - name: ignore_serviceaccount_users
@@ -904,7 +904,7 @@ objects:
         namespace: openshift-security
       spec:
         image: quay.io/redhat-services-prod/openshift/splunk-forwarder-images
-        imageDigest: sha256:e400fcba1cccfa503e93127fd914a8b262857abdc72b0c6eade9b911ac9939ab
+        imageDigest: sha256:534d2dc94dcc28f99f7358a0a55683f0f6b93e23141e28073e81287e63353399
         splunkLicenseAccepted: true
         splunkInputs:
         - index: rh_osd_cluster_audit_stage

--- a/hack/pko/clusterpackage.yaml
+++ b/hack/pko/clusterpackage.yaml
@@ -143,7 +143,7 @@ objects:
           name: splunkforwarder
           namespace: openshift-security
         spec:
-          image: quay.io/app-sre/splunk-forwarder
+          image: quay.io/redhat-services-prod/openshift/splunk-forwarder-images
           imageDigest: sha256:e400fcba1cccfa503e93127fd914a8b262857abdc72b0c6eade9b911ac9939ab
           splunkLicenseAccepted: true
           filters:
@@ -232,7 +232,7 @@ objects:
           name: splunkforwarder
           namespace: openshift-security
         spec:
-          image: quay.io/app-sre/splunk-forwarder
+          image: quay.io/redhat-services-prod/openshift/splunk-forwarder-images
           imageDigest: sha256:e400fcba1cccfa503e93127fd914a8b262857abdc72b0c6eade9b911ac9939ab
           splunkLicenseAccepted: true
           splunkInputs:
@@ -290,7 +290,7 @@ objects:
             name: splunkforwarder
             namespace: openshift-security
           spec:
-            image: quay.io/app-sre/splunk-forwarder
+            image: quay.io/redhat-services-prod/openshift/splunk-forwarder-images
             imageDigest: sha256:e400fcba1cccfa503e93127fd914a8b262857abdc72b0c6eade9b911ac9939ab
             splunkLicenseAccepted: true
             splunkInputs:
@@ -364,7 +364,7 @@ objects:
             name: splunkforwarder
             namespace: openshift-security
           spec:
-            image: quay.io/app-sre/splunk-forwarder
+            image: quay.io/redhat-services-prod/openshift/splunk-forwarder-images
             imageDigest: sha256:e400fcba1cccfa503e93127fd914a8b262857abdc72b0c6eade9b911ac9939ab
             splunkLicenseAccepted: true
             filters:
@@ -452,7 +452,7 @@ objects:
             name: splunkforwarder
             namespace: openshift-security
           spec:
-            image: quay.io/app-sre/splunk-forwarder
+            image: quay.io/redhat-services-prod/openshift/splunk-forwarder-images
             imageDigest: sha256:e400fcba1cccfa503e93127fd914a8b262857abdc72b0c6eade9b911ac9939ab
             splunkLicenseAccepted: true
             splunkInputs:
@@ -518,7 +518,7 @@ objects:
             name: splunkforwarder
             namespace: openshift-security
           spec:
-            image: quay.io/app-sre/splunk-forwarder
+            image: quay.io/redhat-services-prod/openshift/splunk-forwarder-images
             imageDigest: sha256:e400fcba1cccfa503e93127fd914a8b262857abdc72b0c6eade9b911ac9939ab
             splunkLicenseAccepted: true
             filters:
@@ -607,7 +607,7 @@ objects:
           name: splunkforwarder
           namespace: openshift-security
         spec:
-          image: quay.io/app-sre/splunk-forwarder
+          image: quay.io/redhat-services-prod/openshift/splunk-forwarder-images
           imageDigest: sha256:e400fcba1cccfa503e93127fd914a8b262857abdc72b0c6eade9b911ac9939ab
           splunkLicenseAccepted: true
           filters:
@@ -711,7 +711,7 @@ objects:
           name: splunkforwarder
           namespace: openshift-security
         spec:
-          image: quay.io/app-sre/splunk-forwarder
+          image: quay.io/redhat-services-prod/openshift/splunk-forwarder-images
           imageDigest: sha256:e400fcba1cccfa503e93127fd914a8b262857abdc72b0c6eade9b911ac9939ab
           splunkLicenseAccepted: true
           splunkInputs:

--- a/hack/pko/clusterpackage.yaml
+++ b/hack/pko/clusterpackage.yaml
@@ -144,7 +144,7 @@ objects:
           namespace: openshift-security
         spec:
           image: quay.io/redhat-services-prod/openshift/splunk-forwarder-images
-          imageDigest: sha256:e400fcba1cccfa503e93127fd914a8b262857abdc72b0c6eade9b911ac9939ab
+          imageDigest: sha256:534d2dc94dcc28f99f7358a0a55683f0f6b93e23141e28073e81287e63353399
           splunkLicenseAccepted: true
           filters:
           - name: ignore_serviceaccount_users
@@ -233,7 +233,7 @@ objects:
           namespace: openshift-security
         spec:
           image: quay.io/redhat-services-prod/openshift/splunk-forwarder-images
-          imageDigest: sha256:e400fcba1cccfa503e93127fd914a8b262857abdc72b0c6eade9b911ac9939ab
+          imageDigest: sha256:534d2dc94dcc28f99f7358a0a55683f0f6b93e23141e28073e81287e63353399
           splunkLicenseAccepted: true
           splunkInputs:
           - path: /host/var/log/pods/*_ip-*-*-*-*ec2internal-debug_*/container-*/*.log
@@ -291,7 +291,7 @@ objects:
             namespace: openshift-security
           spec:
             image: quay.io/redhat-services-prod/openshift/splunk-forwarder-images
-            imageDigest: sha256:e400fcba1cccfa503e93127fd914a8b262857abdc72b0c6eade9b911ac9939ab
+            imageDigest: sha256:534d2dc94dcc28f99f7358a0a55683f0f6b93e23141e28073e81287e63353399
             splunkLicenseAccepted: true
             splunkInputs:
               - path: /host/var/log/hypershift-osd-audit/*/audit.log
@@ -365,7 +365,7 @@ objects:
             namespace: openshift-security
           spec:
             image: quay.io/redhat-services-prod/openshift/splunk-forwarder-images
-            imageDigest: sha256:e400fcba1cccfa503e93127fd914a8b262857abdc72b0c6eade9b911ac9939ab
+            imageDigest: sha256:534d2dc94dcc28f99f7358a0a55683f0f6b93e23141e28073e81287e63353399
             splunkLicenseAccepted: true
             filters:
               - name: ignore_serviceaccount_users
@@ -453,7 +453,7 @@ objects:
             namespace: openshift-security
           spec:
             image: quay.io/redhat-services-prod/openshift/splunk-forwarder-images
-            imageDigest: sha256:e400fcba1cccfa503e93127fd914a8b262857abdc72b0c6eade9b911ac9939ab
+            imageDigest: sha256:534d2dc94dcc28f99f7358a0a55683f0f6b93e23141e28073e81287e63353399
             splunkLicenseAccepted: true
             splunkInputs:
               - path: /host/var/log/hypershift-osd-audit/*/audit.log
@@ -519,7 +519,7 @@ objects:
             namespace: openshift-security
           spec:
             image: quay.io/redhat-services-prod/openshift/splunk-forwarder-images
-            imageDigest: sha256:e400fcba1cccfa503e93127fd914a8b262857abdc72b0c6eade9b911ac9939ab
+            imageDigest: sha256:534d2dc94dcc28f99f7358a0a55683f0f6b93e23141e28073e81287e63353399
             splunkLicenseAccepted: true
             filters:
               - name: ignore_serviceaccount_users
@@ -608,7 +608,7 @@ objects:
           namespace: openshift-security
         spec:
           image: quay.io/redhat-services-prod/openshift/splunk-forwarder-images
-          imageDigest: sha256:e400fcba1cccfa503e93127fd914a8b262857abdc72b0c6eade9b911ac9939ab
+          imageDigest: sha256:534d2dc94dcc28f99f7358a0a55683f0f6b93e23141e28073e81287e63353399
           splunkLicenseAccepted: true
           filters:
           - name: ignore_serviceaccount_users
@@ -712,7 +712,7 @@ objects:
           namespace: openshift-security
         spec:
           image: quay.io/redhat-services-prod/openshift/splunk-forwarder-images
-          imageDigest: sha256:e400fcba1cccfa503e93127fd914a8b262857abdc72b0c6eade9b911ac9939ab
+          imageDigest: sha256:534d2dc94dcc28f99f7358a0a55683f0f6b93e23141e28073e81287e63353399
           splunkLicenseAccepted: true
           splunkInputs:
           - index: rh_osd_cluster_audit_stage

--- a/samples/splunkforwarder_v1alpha1_splunkforwarder_cr.yaml
+++ b/samples/splunkforwarder_v1alpha1_splunkforwarder_cr.yaml
@@ -4,7 +4,7 @@ metadata:
   name: example-splunkforwarder
 spec:
   image: quay.io/redhat-services-prod/openshift/splunk-forwarder-images
-  imageDigest: sha256:2452a3f01e840661ee1194777ed5a9185ceaaa9ec7329ed364fa2f02be22a701
+  imageDigest: sha256:534d2dc94dcc28f99f7358a0a55683f0f6b93e23141e28073e81287e63353399
   splunkLicenseAccepted: true
   clusterID: mycluster
   splunkInputs:

--- a/samples/splunkforwarder_v1alpha1_splunkforwarder_cr.yaml
+++ b/samples/splunkforwarder_v1alpha1_splunkforwarder_cr.yaml
@@ -3,7 +3,7 @@ kind: SplunkForwarder
 metadata:
   name: example-splunkforwarder
 spec:
-  image: quay.io/app-sre/splunk-forwarder
+  image: quay.io/redhat-services-prod/openshift/splunk-forwarder-images
   imageDigest: sha256:2452a3f01e840661ee1194777ed5a9185ceaaa9ec7329ed364fa2f02be22a701
   splunkLicenseAccepted: true
   clusterID: mycluster

--- a/test/e2e/splunk_forwarder_operator_tests.go
+++ b/test/e2e/splunk_forwarder_operator_tests.go
@@ -411,7 +411,7 @@ var _ = ginkgo.Describe("Splunk Forwarder Operator", ginkgo.Ordered, func() {
 			},
 			Spec: sfv1alpha1.SplunkForwarderSpec{
 				SplunkLicenseAccepted: true,
-				Image:                 "quay.io/app-sre/splunk-forwarder",
+				Image:                 "quay.io/redhat-services-prod/openshift/splunk-forwarder-images",
 				ImageTag:              "latest",
 				ClusterID:             "multi-index-cluster",
 				SplunkInputs: []sfv1alpha1.SplunkForwarderInputs{

--- a/test/e2e/utils.go
+++ b/test/e2e/utils.go
@@ -53,7 +53,7 @@ func makeSplunkforwarderWithIndex(name, namespace, path, index, sourcetype strin
 		},
 		Spec: sfv1alpha1.SplunkForwarderSpec{
 			SplunkLicenseAccepted: true,
-			Image:                 "quay.io/app-sre/splunk-forwarder",
+			Image:                 "quay.io/redhat-services-prod/openshift/splunk-forwarder-images",
 			ImageTag:              "latest",
 			SplunkInputs: []sfv1alpha1.SplunkForwarderInputs{
 				{


### PR DESCRIPTION
Updated all references from quay.io/app-sre/splunk-forwarder to quay.io/redhat-services-prod/openshift/splunk-forwarder-images to use the new Konflux-built splunk-forwarder-images.

Updated files:
- hack/pko/clusterpackage.yaml (8 occurrences)
- hack/olm-registry/olm-artifacts-template.yaml (8 occurrences)
- samples/splunkforwarder_v1alpha1_splunkforwarder_cr.yaml
- test/e2e/utils.go
- test/e2e/splunk_forwarder_operator_tests.go
- README.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Splunk forwarder container image repository and image digest across documentation, operator templates, sample custom resources, packaging artifacts, and end-to-end tests. All references and examples now point to the new container image source and corresponding digest to ensure consistency between docs, manifests, and test resources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->