### PR TITLE
Remove OLM catalog service check from e2e tests

### DIFF
--- a/test/e2e/splunk_forwarder_operator_tests.go
+++ b/test/e2e/splunk_forwarder_operator_tests.go
@@ -31,8 +31,7 @@ var (
 	k8s            *openshift.Client
 	deploymentName = "splunk-forwarder-operator"
 	operatorName   = "splunk-forwarder-operator"
-	serviceNames   = []string{"splunk-forwarder-operator-metrics",
-		"splunk-forwarder-operator-catalog"}
+	serviceNames   = []string{"splunk-forwarder-operator-metrics"}
 	rolePrefix                    = "splunk-forwarder-operator"
 	testSplunkForwarder           = "osde2e-splunkforwarder-test-2"
 	dedicatedAdminSplunkForwarder = "osde2e-dedicated-admin-splunkforwarder-x"


### PR DESCRIPTION
Removed 'splunk-forwarder-operator-catalog' from serviceNames check as this service is OLM-specific and does not exist with PKO deployments.

The catalog service is created by OLM's CatalogSource, which is not used in the PKO deployment model. Now that we've migrated from OLM to PKO in integration and staging environments, this check was causing e2e test failures.

The metrics service check remains as it should exist in both OLM and PKO deployments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated end-to-end test to verify only the `splunk-forwarder-operator-metrics` service in the operator namespace.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->