### PR TITLE
Add Subscription and CatalogSource cleanup to OLM cleanup job

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -3,7 +3,7 @@ COPY . /go/src/github.com/openshift/splunk-forwarder-operator
 WORKDIR /go/src/github.com/openshift/splunk-forwarder-operator
 RUN make go-build
 
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7-1776833838
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7-1777857961
 ENV OPERATOR_PATH=/go/src/github.com/openshift/splunk-forwarder-operator \
     OPERATOR_BIN=splunk-forwarder-operator
 

--- a/build/Dockerfile.olm-registry
+++ b/build/Dockerfile.olm-registry
@@ -4,7 +4,7 @@ COPY ${SAAS_OPERATOR_DIR} manifests
 RUN initializer --permissive
 
 # ubi-micro does not work for clusters with fips enabled unless we make OpenSSL available
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7-1776833838
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7-1777857961
 
 COPY --from=builder /bin/registry-server /bin/registry-server
 COPY --from=builder /bin/grpc_health_probe /bin/grpc_health_probe

--- a/deploy_pko/.test-fixtures/default/Cleanup-OLM-Job.yaml
+++ b/deploy_pko/.test-fixtures/default/Cleanup-OLM-Job.yaml
@@ -32,6 +32,7 @@ rules:
     resources:
       - clusterserviceversions
       - subscriptions
+      - catalogsources
     verbs:
       - list
       - get
@@ -83,15 +84,14 @@ spec:
             - |
               #!/bin/sh
               set -euxo pipefail
-              # CUSTOMIZE: Update the label selector for your operator
-              # Example pattern: operators.coreos.com/OPERATOR_NAME.NAMESPACE
-              oc -n openshift-splunk-forwarder-operator delete csv -l "operators.coreos.com/splunk-forwarder-operator.openshift-splunk-forwarder-operator" || true
-              
-              # CUSTOMIZE: Add any additional cleanup logic here
-              # Examples:
-              # - Delete subscriptions
-              # - Delete operator groups
-              # - Clean up custom resources
+              # Delete CSV
+              oc -n openshift-splunk-forwarder-operator delete csv -l "operators.coreos.com/splunk-forwarder-operator.openshift-splunk-forwarder-operator" --ignore-not-found=true
+
+              # Delete Subscription
+              oc -n openshift-splunk-forwarder-operator delete subscription openshift-splunk-forwarder-operator --ignore-not-found=true
+
+              # Delete CatalogSource
+              oc -n openshift-splunk-forwarder-operator delete catalogsource splunk-forwarder-operator-catalog --ignore-not-found=true
           resources:
             requests:
               cpu: 100m

--- a/deploy_pko/Cleanup-OLM-Job.yaml.gotmpl
+++ b/deploy_pko/Cleanup-OLM-Job.yaml.gotmpl
@@ -83,15 +83,14 @@ spec:
             - |
               #!/bin/sh
               set -euxo pipefail
-              # CUSTOMIZE: Update the label selector for your operator
-              # Example pattern: operators.coreos.com/OPERATOR_NAME.NAMESPACE
+              # Delete CSV
               oc -n {{ .config.namespace }} delete csv -l "operators.coreos.com/splunk-forwarder-operator.{{ .config.namespace }}" || true
-              
-              # CUSTOMIZE: Add any additional cleanup logic here
-              # Examples:
-              # - Delete subscriptions
-              # - Delete operator groups
-              # - Clean up custom resources
+
+              # Delete Subscription
+              oc -n {{ .config.namespace }} delete subscription openshift-splunk-forwarder-operator || true
+
+              # Delete CatalogSource
+              oc -n {{ .config.namespace }} delete catalogsource splunk-forwarder-operator-catalog || true
           resources:
             requests:
               cpu: 100m

--- a/deploy_pko/Cleanup-OLM-Job.yaml.gotmpl
+++ b/deploy_pko/Cleanup-OLM-Job.yaml.gotmpl
@@ -32,6 +32,7 @@ rules:
     resources:
       - clusterserviceversions
       - subscriptions
+      - catalogsources
     verbs:
       - list
       - get
@@ -84,13 +85,13 @@ spec:
               #!/bin/sh
               set -euxo pipefail
               # Delete CSV
-              oc -n {{ .config.namespace }} delete csv -l "operators.coreos.com/splunk-forwarder-operator.{{ .config.namespace }}" || true
+              oc -n {{ .config.namespace }} delete csv -l "operators.coreos.com/splunk-forwarder-operator.{{ .config.namespace }}" --ignore-not-found=true
 
               # Delete Subscription
-              oc -n {{ .config.namespace }} delete subscription openshift-splunk-forwarder-operator || true
+              oc -n {{ .config.namespace }} delete subscription openshift-splunk-forwarder-operator --ignore-not-found=true
 
               # Delete CatalogSource
-              oc -n {{ .config.namespace }} delete catalogsource splunk-forwarder-operator-catalog || true
+              oc -n {{ .config.namespace }} delete catalogsource splunk-forwarder-operator-catalog --ignore-not-found=true
           resources:
             requests:
               cpu: 100m


### PR DESCRIPTION
Extended the OLM cleanup job to delete all OLM resources, not just CSVs:
- CSV (existing cleanup via label selector)
- Subscription: openshift-splunk-forwarder-operator
- CatalogSource: splunk-forwarder-operator-catalog

This ensures complete OLM cleanup during the OLM-to-PKO migration, preventing orphaned Subscription and CatalogSource resources from remaining on management clusters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced OLM cleanup process to explicitly remove ClusterServiceVersion resources, Subscriptions, and CatalogSources with improved error handling to ensure cleanup operations complete reliably even when individual deletions fail.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->