### PR TITLE
Fix OLM cleanup RBAC by specifying API group in delete commands

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -3,7 +3,7 @@ COPY . /go/src/github.com/openshift/splunk-forwarder-operator
 WORKDIR /go/src/github.com/openshift/splunk-forwarder-operator
 RUN make go-build
 
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7-1777857961
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7-1778072020
 ENV OPERATOR_PATH=/go/src/github.com/openshift/splunk-forwarder-operator \
     OPERATOR_BIN=splunk-forwarder-operator
 

--- a/build/Dockerfile.olm-registry
+++ b/build/Dockerfile.olm-registry
@@ -4,7 +4,7 @@ COPY ${SAAS_OPERATOR_DIR} manifests
 RUN initializer --permissive
 
 # ubi-micro does not work for clusters with fips enabled unless we make OpenSSL available
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7-1777857961
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7-1778072020
 
 COPY --from=builder /bin/registry-server /bin/registry-server
 COPY --from=builder /bin/grpc_health_probe /bin/grpc_health_probe

--- a/deploy_pko/.test-fixtures/default/Cleanup-OLM-Job.yaml
+++ b/deploy_pko/.test-fixtures/default/Cleanup-OLM-Job.yaml
@@ -87,11 +87,11 @@ spec:
               # Delete CSV
               oc -n openshift-splunk-forwarder-operator delete csv -l "operators.coreos.com/splunk-forwarder-operator.openshift-splunk-forwarder-operator" --ignore-not-found=true
 
-              # Delete Subscription
-              oc -n openshift-splunk-forwarder-operator delete subscription openshift-splunk-forwarder-operator --ignore-not-found=true
+              # Delete Subscription (specify API group to avoid ambiguity with OCM subscriptions)
+              oc -n openshift-splunk-forwarder-operator delete subscription.operators.coreos.com openshift-splunk-forwarder-operator --ignore-not-found=true
 
-              # Delete CatalogSource
-              oc -n openshift-splunk-forwarder-operator delete catalogsource splunk-forwarder-operator-catalog --ignore-not-found=true
+              # Delete CatalogSource (specify API group for consistency)
+              oc -n openshift-splunk-forwarder-operator delete catalogsource.operators.coreos.com splunk-forwarder-operator-catalog --ignore-not-found=true
           resources:
             requests:
               cpu: 100m

--- a/deploy_pko/Cleanup-OLM-Job.yaml.gotmpl
+++ b/deploy_pko/Cleanup-OLM-Job.yaml.gotmpl
@@ -87,11 +87,11 @@ spec:
               # Delete CSV
               oc -n {{ .config.namespace }} delete csv -l "operators.coreos.com/splunk-forwarder-operator.{{ .config.namespace }}" --ignore-not-found=true
 
-              # Delete Subscription
-              oc -n {{ .config.namespace }} delete subscription openshift-splunk-forwarder-operator --ignore-not-found=true
+              # Delete Subscription (specify API group to avoid ambiguity with OCM subscriptions)
+              oc -n {{ .config.namespace }} delete subscription.operators.coreos.com openshift-splunk-forwarder-operator --ignore-not-found=true
 
-              # Delete CatalogSource
-              oc -n {{ .config.namespace }} delete catalogsource splunk-forwarder-operator-catalog --ignore-not-found=true
+              # Delete CatalogSource (specify API group for consistency)
+              oc -n {{ .config.namespace }} delete catalogsource.operators.coreos.com splunk-forwarder-operator-catalog --ignore-not-found=true
           resources:
             requests:
               cpu: 100m


### PR DESCRIPTION
The cleanup job was failing with RBAC errors when trying to delete subscriptions because kubectl was ambiguously selecting the wrong API group (apps.open-cluster-management.io instead of operators.coreos.com).

Changes:
- Updated delete commands to use fully qualified resource types:
  - subscription → subscription.operators.coreos.com
  - catalogsource → catalogsource.operators.coreos.com
- Added explanatory comments about API group disambiguation
- Regenerated PKO test fixtures

This fixes the error:
"subscriptions.apps.open-cluster-management.io is forbidden"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced OLM cleanup process by using explicit API-group-qualified resource identifiers for Subscription and CatalogSource deletions, improving cleanup reliability and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->