### PR TITLE
Add OperatorGroup deletion to OLM cleanup job

### DIFF
--- a/deploy_pko/.test-fixtures/default/Cleanup-OLM-Job.yaml
+++ b/deploy_pko/.test-fixtures/default/Cleanup-OLM-Job.yaml
@@ -33,6 +33,7 @@ rules:
       - clusterserviceversions
       - subscriptions
       - catalogsources
+      - operatorgroups
     verbs:
       - list
       - get
@@ -92,6 +93,9 @@ spec:
 
               # Delete CatalogSource (specify API group for consistency)
               oc -n openshift-splunk-forwarder-operator delete catalogsource.operators.coreos.com splunk-forwarder-operator-catalog --ignore-not-found=true
+
+              # Delete OperatorGroup (specify API group for consistency)
+              oc -n openshift-splunk-forwarder-operator delete operatorgroup.operators.coreos.com splunk-forwarder-operator-og --ignore-not-found=true
           resources:
             requests:
               cpu: 100m

--- a/deploy_pko/Cleanup-OLM-Job.yaml.gotmpl
+++ b/deploy_pko/Cleanup-OLM-Job.yaml.gotmpl
@@ -33,6 +33,7 @@ rules:
       - clusterserviceversions
       - subscriptions
       - catalogsources
+      - operatorgroups
     verbs:
       - list
       - get
@@ -92,6 +93,9 @@ spec:
 
               # Delete CatalogSource (specify API group for consistency)
               oc -n {{ .config.namespace }} delete catalogsource.operators.coreos.com splunk-forwarder-operator-catalog --ignore-not-found=true
+
+              # Delete OperatorGroup (specify API group for consistency)
+              oc -n {{ .config.namespace }} delete operatorgroup.operators.coreos.com splunk-forwarder-operator-og --ignore-not-found=true
           resources:
             requests:
               cpu: 100m


### PR DESCRIPTION
Extended the cleanup job to also delete the OperatorGroup resource that was left behind during OLM-to-PKO migration.

Changes:
- Added operatorgroups to RBAC permissions
- Added delete command for splunk-forwarder-operator-og OperatorGroup
- Regenerated PKO test fixtures

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced cleanup process to properly remove OperatorGroup resources during operator cleanup operations, ensuring complete removal of associated components and preventing orphaned resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->