### PR TITLE
SREP-4862: Clear quay.expires-after label from push pipeline builds

### DIFF
--- a/.tekton/splunk-forwarder-operator-e2e-push.yaml
+++ b/.tekton/splunk-forwarder-operator-e2e-push.yaml
@@ -28,6 +28,8 @@ spec:
     value: test/e2e/Dockerfile
   - name: path-context
     value: .
+  - name: image-expires-after
+    value: ""
   taskRunTemplate:
     serviceAccountName: build-pipeline-splunk-forwarder-operator-e2e
   workspaces:

--- a/.tekton/splunk-forwarder-operator-pko-push.yaml
+++ b/.tekton/splunk-forwarder-operator-pko-push.yaml
@@ -29,6 +29,8 @@ spec:
     value: deploy_pko
   - name: skip-preflight-cert-check
     value: true
+  - name: image-expires-after
+    value: ""
   taskRunTemplate:
     serviceAccountName: build-pipeline-splunk-forwarder-operator-pko
   workspaces:

--- a/.tekton/splunk-forwarder-operator-push.yaml
+++ b/.tekton/splunk-forwarder-operator-push.yaml
@@ -30,6 +30,8 @@ spec:
     value: build/Dockerfile
   - name: path-context
     value: .
+  - name: image-expires-after
+    value: ""
   taskRunTemplate:
     serviceAccountName: build-pipeline-splunk-forwarder-operator
   workspaces:


### PR DESCRIPTION
## Summary
- The EC (Enterprise Contract) verification fails on all 3 push-built images because they have `quay.expires-after` labels (5d for operator/e2e, 3d for pko)
- This causes images to auto-delete from quay.io, breaking the Konflux release pipeline
- SFO has been broken in int/stage since May 13 because of this

## Fix
Add `image-expires-after: ""` to all 3 push pipeline files to explicitly clear the label:
- `.tekton/splunk-forwarder-operator-push.yaml`
- `.tekton/splunk-forwarder-operator-pko-push.yaml`
- `.tekton/splunk-forwarder-operator-e2e-push.yaml`

The PR pipelines already set this param (5d/3d) which is correct for ephemeral PR images. Push pipelines need it cleared so production images persist.

Jira: https://redhat.atlassian.net/browse/SREP-4862

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build pipeline configurations to support image expiration settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->