### PR TITLE
Remove path filter from operator push pipeline

### DIFF
--- a/.tekton/splunk-forwarder-operator-push.yaml
+++ b/.tekton/splunk-forwarder-operator-push.yaml
@@ -7,10 +7,8 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: 'false'
     pipelinesascode.tekton.dev/max-keep-runs: '3'
-    pipelinesascode.tekton.dev/on-cel-expression: "event == \"push\" \n&& target_branch\
-      \ == \"master\"\n&& (\"{.,**}/*.go\".pathChanged() ||\n    \"{.,**}/go.*\".pathChanged()\
-      \ ||\n    \"build/Dockerfile\".pathChanged() ||\n    \".tekton/splunk-forwarder-operator-push.yaml\"\
-      .pathChanged() ) \n"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
+      == "master"
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: splunk-forwarder-operator


### PR DESCRIPTION
## Summary

- Remove the CEL path filter from the operator binary push pipeline so it triggers on every push to master, matching the PKO and E2E push pipelines

## Problem

The operator push pipeline had a CEL pathChanged() filter that only triggered when Go files, go.mod, build/Dockerfile, or the tekton YAML itself changed. The PKO and E2E push pipelines trigger on every push to master with no path filter.

When non-Go commits merge (OWNERS, .coderabbit.yaml, etc.), the operator binary never builds. The Konflux release snapshot then has no new operator image to push to quay, while the PKO bundle and E2E images release fine. App-interface promotes the ref to stage, and clusters hit ImagePullBackOff because the operator image tag does not exist.

This caused three staging breakages:
- 20e56d7 (May 8)
- 88595e1 (May 13, OWNERS change)
- 926f030 (May 28, .coderabbit.yaml)

Slack thread: https://redhat-internal.slack.com/archives/CFJD1NZFT/p1778229462717119

## Test plan

- [ ] Merge a non-Go change and verify the operator binary build triggers in Konflux
- [ ] Verify all three component images appear in quay with the new commit tag

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified CI/CD pipeline trigger configuration. Updated the push event condition to a more direct approach, removing path-based filtering. The pipeline now triggers on all push events targeting the master branch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->