### PR TITLE
fix: restore pre-commit hook wording in gitleaks.toml

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -2,7 +2,7 @@
 # https://github.com/gitleaks/gitleaks
 #
 # Purpose: Detect hardcoded secrets, credentials, and sensitive data
-# Integration: Runs via prek and Tekton CI
+# Integration: Runs in pre-commit hook (via prek) and Tekton CI
 #
 # Usage:
 #   gitleaks detect --source . --verbose


### PR DESCRIPTION
## Summary

Fixes a comment wording in `.gitleaks.toml` that was incorrectly changed in #447.

**Before (merged in #447):**
```
# Integration: Runs via prek and Tekton CI
```

**After:**
```
# Integration: Runs in pre-commit hook (via prek) and Tekton CI
```

"pre-commit hook" is standard git terminology describing the hook type (the git hook that fires before each commit) — it is not a reference to the `pre-commit` Python tool. The change in #447 was an over-correction; this restores the accurate description while keeping the explicit `prek` tool reference.

The usage command (`prek run gitleaks`) from #447 is correct and unchanged.

Flagged by @boranx in PR review.