### PR TITLE
[Project Darkstar] PSHP-541: Remediate stdlib CVEs in splunk-forwarder-operator

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,7 @@
 module github.com/openshift/splunk-forwarder-operator
 
 go 1.25.9
+toolchain go1.25.11
 
 require (
 	github.com/onsi/ginkgo/v2 v2.9.5


### PR DESCRIPTION
## Project Darkstar — Automated CVE Remediation

> **This PR was generated by Project Darkstar**, an automated CVE remediation tool.
> For questions or concerns, contact **Kevin Seiter** (ROSA Trust Engineering).

## Summary

Adds `toolchain go1.25.11` directive to `go.mod` to remediate 9 IMPORTANT Go stdlib CVEs confirmed by ACS runtime scanning across 10 production clusters.

## CVEs Addressed

| CVE | Severity | CVSS | Description |
|-----|----------|------|-------------|
| CVE-2026-25679 | IMPORTANT | 7.5 | stdlib — fixed in go1.25.8 |
| CVE-2026-32280 | IMPORTANT | 7.5 | stdlib — fixed in go1.25.9 |
| CVE-2026-32283 | IMPORTANT | 7.5 | Unauthenticated TLS 1.3 KeyUpdate DoS in crypto/tls — fixed in go1.25.9 |
| CVE-2026-33811 | IMPORTANT | 7.5 | Crash on long CNAME response in net — fixed in go1.25.10 |
| CVE-2026-33814 | IMPORTANT | 7.5 | Infinite loop in HTTP/2 transport in net/http — fixed in go1.25.10 |
| CVE-2026-39820 | IMPORTANT | 7.5 | Quadratic string concat in net/mail — fixed in go1.25.10 |
| CVE-2026-42499 | IMPORTANT | 7.5 | stdlib — fixed in go1.25.10 |
| CVE-2026-27145 | IMPORTANT | 7.5 | stdlib — fixed in go1.25.11 |
| CVE-2026-42504 | IMPORTANT | 7.5 | stdlib — fixed in go1.25.11 |

## Changes

- `go.mod`: added `toolchain go1.25.11` (the `go 1.25.9` language-version directive is unchanged)

## Not In This PR (handled separately)

- **x/net CVEs** (CVE-2026-39821, CVE-2026-27136, CVE-2026-25681): already fixed by commit 3d1c424 (x/net bumped to v0.55.0)
- **RPM CVEs** (gnutls, openssl-libs, libcap, krb5-libs): Dependabot PR in flight to bump UBI base image
- **CVE-2026-58016** (glib2), **CVE-2026-54369** (libacl): no fix available upstream

## ACS Runtime Exposure

The following CVEs were confirmed detected by ACS runtime scanning:
CVE-2026-25679, CVE-2026-32280, CVE-2026-32283, CVE-2026-33811, CVE-2026-33814, CVE-2026-39820, CVE-2026-42499, CVE-2026-27145, CVE-2026-42504

## Verification

- [ ] `go build ./...` passes
- [ ] `make test` passes
- [ ] No regressions in existing functionality

## Team Context

- **Slack:** #hcm-team-security
- **Jira project:** HCMSEC
- **Manager:** Amber Krawczyk (akrawczy)

## References

- Jira: [PSHP-541](https://redhat.atlassian.net/browse/PSHP-541)
- FedRAMP SLA: 30 days from 2026-07-04 scan (~2026-08-03)

---
**Project Darkstar** — Automated CVE Remediation | Contact: Kevin Seiter (ROSA Trust Engineering)

[PSHP-541]: https://redhat.atlassian.net/browse/PSHP-541?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Pinned the project’s build toolchain to Go 1.25.11 for more consistent builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->