### PR TITLE
Fix audit-exporter SCC denial by specifying sfo serviceAccountName

### DIFF
--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -1007,6 +1007,7 @@ objects:
         template:
           metadata: *id002
           spec:
+            serviceAccountName: splunk-forwarder-operator
             automountServiceAccountToken: false
             containers:
             - name: audit-exporter

--- a/hack/pko/clusterpackage.yaml
+++ b/hack/pko/clusterpackage.yaml
@@ -812,6 +812,7 @@ objects:
           template:
             metadata: *id002
             spec:
+              serviceAccountName: splunk-forwarder-operator
               automountServiceAccountToken: false
               containers:
               - name: audit-exporter


### PR DESCRIPTION
### Summary
Set `serviceAccountName: splunk-forwarder-operator` on the `audit-exporter` DaemonSet in the OLM artifact and PKO templates.

Follow up to https://github.com/openshift/splunk-forwarder-operator/pull/457

### Why
https://github.com/openshift/splunk-forwarder-operator/pull/457 migrated `splunkforwarder` SCC grant from the `default` serviceaccount to a dedicated serviceaccount: `splunk-forwarder-operator`. This broken deployment of the audit-exporter component. The `audit-exporter` daemonset does not specify a `serviceAccountName`, and therefore defaults to using the `default` service account. Because audit-exporter requires `privlieged: true` and `runAsUser: 0`, it too requires the SCC grants that have been moved to `splunk-forwarder-operator`



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the audit exporter to run with the appropriate service account, improving deployment permissions and reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->