### PR TITLE
[Project Darkstar] ROSAENG-63319: Remediate 4 CVEs in splunk-forwarder-operator

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -3,7 +3,7 @@ COPY . /go/src/github.com/openshift/splunk-forwarder-operator
 WORKDIR /go/src/github.com/openshift/splunk-forwarder-operator
 RUN make go-build
 
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.8-1784705586
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.8-1785777232
 ENV OPERATOR_PATH=/go/src/github.com/openshift/splunk-forwarder-operator \
     OPERATOR_BIN=splunk-forwarder-operator
 

--- a/build/Dockerfile.olm-registry
+++ b/build/Dockerfile.olm-registry
@@ -4,7 +4,7 @@ COPY ${SAAS_OPERATOR_DIR} manifests
 RUN initializer --permissive
 
 # ubi-micro does not work for clusters with fips enabled unless we make OpenSSL available
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.8-1784705586
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.8-1785777232
 
 COPY --from=builder /bin/registry-server /bin/registry-server
 COPY --from=builder /bin/grpc_health_probe /bin/grpc_health_probe

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/openshift/splunk-forwarder-operator
 
 go 1.25.9
 
+toolchain go1.25.12
+
 require (
 	github.com/onsi/ginkgo/v2 v2.9.5
 	github.com/onsi/gomega v1.27.7


### PR DESCRIPTION
## [Project Darkstar] [ROSAENG-63319](https://redhat.atlassian.net/browse/ROSAENG-63319): Remediate CVEs in splunk-forwarder-operator

### Changes
- Add `toolchain go1.25.12` to go.mod (fixes Go stdlib CVEs)
- Bump UBI base image in build/Dockerfile: `9.8-1784705586` → `9.8-1785777232`
- Bump UBI base image in build/Dockerfile.olm-registry: `9.8-1784705586` → `9.8-1785777232`

### Fixed — Go stdlib (2 CVEs)
- CVE-2026-39822 (stdlib, CVSS 7.5) — fix: Go 1.25.12+
- CVE-2026-42505 (stdlib, CVSS 5.3) — fix: Go 1.25.12+

### Fixed — Base Image (2 CVEs)
- CVE-2026-54369 (libacl, CVSS 7.5) — fixed in UBI 9.8-1785777232
- CVE-2026-5435 (glibc, CVSS 5.3) — fixed in UBI 9.8-1785777232

### Not In This PR
- golang.org/x/net, golang.org/x/text — deferred to MintMaker automation

### No Fix Available
- 14 RPM-level CVEs (curl-minimal, glib2, libarchive, libxml2) — no upstream fix

> **FedRAMP SLA**: Critical/Important CVEs must be remediated within 30 days of detection.

[About Project Darkstar](https://source.redhat.com/departments/products_and_global_engineering/hybridplatforms/hybrid_platforms_blog/introducing_darkstar_an_experiment_in_ai_assisted_cve_remediation_for_rosa)

[ROSAENG-63319]: https://redhat.atlassian.net/browse/ROSAENG-63319

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the required Go toolchain version to 1.25.12 while retaining compatibility with Go 1.25.9.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->