### PR TITLE
Update SAE image to 0c9dd75

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -3,7 +3,7 @@ COPY . /go/src/github.com/openshift/splunk-forwarder-operator
 WORKDIR /go/src/github.com/openshift/splunk-forwarder-operator
 RUN make go-build
 
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.8-1785906621
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.8-1786323074
 ENV OPERATOR_PATH=/go/src/github.com/openshift/splunk-forwarder-operator \
     OPERATOR_BIN=splunk-forwarder-operator
 

--- a/build/Dockerfile.olm-registry
+++ b/build/Dockerfile.olm-registry
@@ -4,7 +4,7 @@ COPY ${SAAS_OPERATOR_DIR} manifests
 RUN initializer --permissive
 
 # ubi-micro does not work for clusters with fips enabled unless we make OpenSSL available
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.8-1785906621
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.8-1786323074
 
 COPY --from=builder /bin/registry-server /bin/registry-server
 COPY --from=builder /bin/grpc_health_probe /bin/grpc_health_probe

--- a/hack/pko/clusterpackage.yaml
+++ b/hack/pko/clusterpackage.yaml
@@ -827,7 +827,7 @@ objects:
                   limits:
                     cpu: 100m
                     memory: 256Mi
-                image: quay.io/redhat-services-prod/splunk-audit-exporter-tenant/splunk-audit-exporter/splunk-audit-exporter@sha256:3748d48a61b5f7206186367484449f6d6219a86e4aa38da9875b8e865c256a18 # 9e7991b
+                image: quay.io/redhat-services-prod/splunk-audit-exporter-tenant/splunk-audit-exporter/splunk-audit-exporter@sha256:9ea4e347b1d7859cda0d2ce21dfcee8a78a0f8c89ac1b7a154e2dcfbba2179c1 # 0c9dd75
                 imagePullPolicy: Always
                 securityContext:
                   privileged: true


### PR DESCRIPTION
## Summary
- Updates splunk-audit-exporter image in `hack/pko/clusterpackage.yaml` from `7a9f63e` to `0c9dd75` (built 2026-08-07)
- Update base image to ubi-minimal 9.8-1786323074

## Test plan
- [ ] Verify clusterpackage deploys audit-exporter with updated image
- [ ] Confirm no regressions in audit log forwarding

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the audit exporter to a newer container image version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->