### PR TITLE
Filter out deletecollection from the namespace cotroller service account

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -3,7 +3,7 @@ COPY . /go/src/github.com/openshift/splunk-forwarder-operator
 WORKDIR /go/src/github.com/openshift/splunk-forwarder-operator
 RUN make go-build
 
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.8-1786323074
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.8-1786380870
 ENV OPERATOR_PATH=/go/src/github.com/openshift/splunk-forwarder-operator \
     OPERATOR_BIN=splunk-forwarder-operator
 

--- a/build/Dockerfile.olm-registry
+++ b/build/Dockerfile.olm-registry
@@ -4,7 +4,7 @@ COPY ${SAAS_OPERATOR_DIR} manifests
 RUN initializer --permissive
 
 # ubi-micro does not work for clusters with fips enabled unless we make OpenSSL available
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.8-1786323074
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.8-1786380870
 
 COPY --from=builder /bin/registry-server /bin/registry-server
 COPY --from=builder /bin/grpc_health_probe /bin/grpc_health_probe

--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -1467,6 +1467,12 @@ objects:
             - group: discovery.k8s.io
               resources: ['endpointslices']
             verbs: ['create','update']
+          # drop deletecollection from namespace-controller SA
+          - level: None
+            users:
+            - 'system:serviceaccount:kube-system:namespace-controller'
+            verbs:
+            - 'deletecollection'
           # forward resources we wish to monitor
           - level: Request
             resources:

--- a/hack/pko/clusterpackage.yaml
+++ b/hack/pko/clusterpackage.yaml
@@ -1278,6 +1278,12 @@ objects:
               - group: discovery.k8s.io
                 resources: ['endpointslices']
               verbs: ['create','update']
+            # drop deletecollection from namespace-controller SA
+            - level: None
+              users:
+              - 'system:serviceaccount:kube-system:namespace-controller'
+              verbs:
+              - 'deletecollection'
             # forward resources we wish to monitor
             - level: Request
               resources:


### PR DESCRIPTION
This is a noisy log entry and we still capture things with the delete verb. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an audit policy rule to exclude namespace-controller `deletecollection` events from audit logs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->