### PR TITLE
fix: handle disabled and default metrics-bind-address

### DIFF
--- a/main.go
+++ b/main.go
@@ -115,16 +115,20 @@ func main() {
 
 	// Derive the metrics Service port from the configured bind address so the
 	// Service always targets the port the metrics server actually listens on.
-	servicePort, err := metricsPortFromAddr(metricsAddr)
+	servicePort, metricsEnabled, err := metricsPortFromAddr(metricsAddr)
 	if err != nil {
 		setupLog.Error(err, "invalid metrics-bind-address", "address", metricsAddr)
 		os.Exit(1)
 	}
 
-	// Add the Metrics Service
-	if err := addMetrics(ctx, mgr.GetClient(), mgr.GetConfig(), servicePort, false); err != nil {
-		log.Error(err, "Metrics service is not added.")
-		os.Exit(1)
+	// Add the Metrics Service, unless metrics are disabled (BindAddress "0").
+	if metricsEnabled {
+		if err := addMetrics(ctx, mgr.GetClient(), mgr.GetConfig(), servicePort, false); err != nil {
+			log.Error(err, "Metrics service is not added.")
+			os.Exit(1)
+		}
+	} else {
+		setupLog.Info("metrics server disabled, skipping metrics Service creation")
 	}
 
 	// Add SplunkForwarder controller to manager
@@ -165,21 +169,31 @@ func main() {
 
 // metricsPortFromAddr extracts the TCP port from a metrics bind address such as
 // ":8383" or "0.0.0.0:8383" so the metrics Service can target the same port the
-// metrics server listens on. It falls back to the default metricsPort when the
-// address omits a port.
-func metricsPortFromAddr(addr string) (int32, error) {
+// metrics server listens on. It mirrors controller-runtime's metrics server
+// address semantics: a bind address of "0" disables the metrics server
+// (enabled=false, and no Service should be created), and an empty address is
+// resolved to metricsserver.DefaultBindAddress before the port is extracted.
+func metricsPortFromAddr(addr string) (port int32, enabled bool, err error) {
+	// "0" disables the metrics server in controller-runtime; no Service needed.
+	if addr == "0" {
+		return 0, false, nil
+	}
+	// An empty address resolves to the controller-runtime default.
+	if addr == "" {
+		addr = metricsserver.DefaultBindAddress
+	}
 	_, portStr, err := net.SplitHostPort(addr)
 	if err != nil {
-		return 0, fmt.Errorf("could not parse metrics bind address %q: %w", addr, err)
+		return 0, false, fmt.Errorf("could not parse metrics bind address %q: %w", addr, err)
 	}
 	if portStr == "" {
-		return metricsPort, nil
+		return metricsPort, true, nil
 	}
-	port, err := strconv.ParseInt(portStr, 10, 32)
+	parsed, err := strconv.ParseInt(portStr, 10, 32)
 	if err != nil {
-		return 0, fmt.Errorf("invalid metrics port in bind address %q: %w", addr, err)
+		return 0, false, fmt.Errorf("invalid metrics port in bind address %q: %w", addr, err)
 	}
-	return int32(port), nil
+	return int32(parsed), true, nil
 }
 
 // addMetrics will create the Services and Service Monitors to allow the operator export the metrics by using

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,93 @@
+package main
+
+import (
+	"testing"
+
+	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
+)
+
+func TestMetricsPortFromAddr(t *testing.T) {
+	tests := []struct {
+		name        string
+		addr        string
+		wantPort    int32
+		wantEnabled bool
+		wantErr     bool
+	}{
+		{
+			name:        "explicit port",
+			addr:        ":9999",
+			wantPort:    9999,
+			wantEnabled: true,
+		},
+		{
+			name:        "host and port",
+			addr:        "0.0.0.0:8383",
+			wantPort:    8383,
+			wantEnabled: true,
+		},
+		{
+			name:        "disabled with zero",
+			addr:        "0",
+			wantPort:    0,
+			wantEnabled: false,
+		},
+		{
+			name:        "empty resolves to controller-runtime default",
+			addr:        "",
+			wantPort:    defaultBindPort(t),
+			wantEnabled: true,
+		},
+		{
+			name:        "missing port falls back to default metricsPort",
+			addr:        "127.0.0.1:",
+			wantPort:    metricsPort,
+			wantEnabled: true,
+		},
+		{
+			name:    "no colon is invalid",
+			addr:    "8383",
+			wantErr: true,
+		},
+		{
+			name:    "non-numeric port is invalid",
+			addr:    ":http",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			port, enabled, err := metricsPortFromAddr(tt.addr)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("metricsPortFromAddr(%q) = (%d, %t, nil); want error", tt.addr, port, enabled)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("metricsPortFromAddr(%q) unexpected error: %v", tt.addr, err)
+			}
+			if port != tt.wantPort {
+				t.Errorf("metricsPortFromAddr(%q) port = %d; want %d", tt.addr, port, tt.wantPort)
+			}
+			if enabled != tt.wantEnabled {
+				t.Errorf("metricsPortFromAddr(%q) enabled = %t; want %t", tt.addr, enabled, tt.wantEnabled)
+			}
+		})
+	}
+}
+
+// defaultBindPort derives the expected port from controller-runtime's
+// DefaultBindAddress so the test stays correct if that default changes.
+func defaultBindPort(t *testing.T) int32 {
+	t.Helper()
+	port, enabled, err := metricsPortFromAddr(metricsserver.DefaultBindAddress)
+	if err != nil {
+		t.Fatalf("could not derive default bind port from %q: %v", metricsserver.DefaultBindAddress, err)
+	}
+	if !enabled {
+		t.Fatalf("default bind address %q unexpectedly disabled", metricsserver.DefaultBindAddress)
+	}
+	return port
+}


### PR DESCRIPTION
## Summary

Follow-up to #474 addressing a late CodeRabbit review comment on the `metricsPortFromAddr` helper introduced there.

`metricsPortFromAddr` didn't match controller-runtime's metrics-server address semantics for two edge cases:

- **`--metrics-bind-address=0`** — controller-runtime treats `"0"` as *disable the metrics server*, but the helper ran it through `net.SplitHostPort`, which errors, causing the operator to `os.Exit(1)` on an otherwise-valid config. The helper now reports `enabled=false` and `main()` skips metrics Service creation.
- **empty address** — controller-runtime resolves an empty `BindAddress` to `metricsserver.DefaultBindAddress` (`:8080`), but the helper returned the hardcoded `8383`, so the Service port would not match the port the server actually binds. The helper now resolves empty to `metricsserver.DefaultBindAddress` before extracting the port.

The default (`:8383`) and explicit-port paths are unchanged.

## Changes (minimal footprint)

- `main.go`: `metricsPortFromAddr` now returns `(port int32, enabled bool, err error)`; `main()` skips `addMetrics` when metrics are disabled.
- `main_test.go` (new): table-driven tests for explicit port, `host:port`, disabled (`"0"`), empty (→ default), missing port, and invalid inputs.

## Verification

- `go build ./...` ✅
- `go vet ./...` ✅
- `go test ./...` (incl. new `TestMetricsPortFromAddr`) ✅

## Not included

The other late comment (make `addMetrics` create-or-update the Service so a changed port reconciles an existing Service) is intentionally out of scope here — it's a larger behavioral change (get/update flow, added RBAC, conflict handling) for an uncommon scenario. Happy to file it separately if desired.