### PR TITLE
Add nodes:get RBAC for leader election library.

### DIFF
--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -48,6 +48,12 @@ rules:
   - list
   - watch
 - apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+- apiGroups:
   - apps
   resources:
   - daemonsets

--- a/deploy_pko/.test-fixtures/default/ClusterRole-openshift-splunk-forwarder-operator.yaml
+++ b/deploy_pko/.test-fixtures/default/ClusterRole-openshift-splunk-forwarder-operator.yaml
@@ -51,6 +51,12 @@ rules:
   - list
   - watch
 - apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+- apiGroups:
   - apps
   resources:
   - daemonsets

--- a/deploy_pko/ClusterRole-openshift-splunk-forwarder-operator.yaml
+++ b/deploy_pko/ClusterRole-openshift-splunk-forwarder-operator.yaml
@@ -51,6 +51,12 @@ rules:
   - list
   - watch
 - apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+- apiGroups:
   - apps
   resources:
   - daemonsets

--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -103,6 +103,12 @@ objects:
         - list
         - watch
       - apiGroups:
+        - ""
+        resources:
+        - nodes
+        verbs:
+        - get
+      - apiGroups:
         - apps
         resources:
         - daemonsets
@@ -278,6 +284,12 @@ objects:
         - '*'
         verbs:
         - '*'
+      - apiGroups:
+        - ""
+        resources:
+        - nodes
+        verbs:
+        - get
       - apiGroups:
         - config.openshift.io
         resources:


### PR DESCRIPTION
RBAC changes require splunk to have nodes:get permissions.

`2026-08-18T21:01:49Z	ERROR	leader	Failed to get Node	{"Node.Name": "ip-10-0-0-44.ec2.internal", "error": "nodes \"ip-10-0-0-44.ec2.internal\" is forbidden: User \"system:serviceaccount:openshift-splunk-forwarder-operator:splunk-forwarder-operator\" cannot get resource \"nodes\" in API group \"\" at the cluster scope"}
`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Permissions**
  * Updated operator permissions to allow read-only access to Kubernetes cluster node information.
  * Applied the permission consistently across Kubernetes and OpenShift deployment configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->