### PR TITLE
Tighten audit-exporter DaemonSet volume mounts 

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -3,7 +3,7 @@ COPY . /go/src/github.com/openshift/splunk-forwarder-operator
 WORKDIR /go/src/github.com/openshift/splunk-forwarder-operator
 RUN make go-build
 
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.8-1786987521
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.8-1787647261
 ENV OPERATOR_PATH=/go/src/github.com/openshift/splunk-forwarder-operator \
     OPERATOR_BIN=splunk-forwarder-operator
 

--- a/build/Dockerfile.olm-registry
+++ b/build/Dockerfile.olm-registry
@@ -4,7 +4,7 @@ COPY ${SAAS_OPERATOR_DIR} manifests
 RUN initializer --permissive
 
 # ubi-micro does not work for clusters with fips enabled unless we make OpenSSL available
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.8-1786987521
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.8-1787647261
 
 COPY --from=builder /bin/registry-server /bin/registry-server
 COPY --from=builder /bin/grpc_health_probe /bin/grpc_health_probe

--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -1075,16 +1075,35 @@ objects:
               image: quay.io/app-sre/splunk-audit-exporter@sha256:798113f5c79248bc24418ff0d149058c04e5eaa35ea7b4ff42a1e6983a37d24a # 0.1.213-118042f
               imagePullPolicy: Always
               securityContext:
-                privileged: true
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                  - ALL
+                privileged: false
+                readOnlyRootFilesystem: true
                 runAsUser: 0
+                seLinuxOptions:
+                  type: container_logwriter_t
               volumeMounts:
               - mountPath: /config
                 name: config
-              - mountPath: /var/log
-                name: logs
+                readOnly: true
+              - mountPath: /var/log/kube-apiserver
+                name: kube-apiserver-logs
+                readOnly: true
+              - mountPath: /var/log/openshift-apiserver
+                name: openshift-apiserver-logs
+                readOnly: true
+              - mountPath: /var/log/oauth-apiserver
+                name: oauth-apiserver-logs
+                readOnly: true
+              - mountPath: /var/log/osd-audit
+                name: osd-audit-logs
               - mountPath: /certs
                 name: tls-certs-secret
                 readOnly: true
+              - mountPath: /tmp
+                name: tmp
             nodeSelector:
               node-role.kubernetes.io/master: ''
             restartPolicy: Always
@@ -1102,10 +1121,24 @@ objects:
             - name: tls-certs-secret
               secret:
                 secretName: audit-exporter-certs
-            - name: logs
+            - name: kube-apiserver-logs
               hostPath:
-                type: Directory
-                path: /var/log
+                path: /var/log/kube-apiserver
+                type: DirectoryOrCreate
+            - name: openshift-apiserver-logs
+              hostPath:
+                path: /var/log/openshift-apiserver
+                type: DirectoryOrCreate
+            - name: oauth-apiserver-logs
+              hostPath:
+                path: /var/log/oauth-apiserver
+                type: DirectoryOrCreate
+            - name: osd-audit-logs
+              hostPath:
+                path: /var/log/osd-audit
+                type: DirectoryOrCreate
+            - name: tmp
+              emptyDir: {}
     - apiVersion: v1
       kind: Service
       metadata:

--- a/hack/pko/clusterpackage.yaml
+++ b/hack/pko/clusterpackage.yaml
@@ -830,16 +830,35 @@ objects:
                 image: quay.io/redhat-services-prod/splunk-audit-exporter-tenant/splunk-audit-exporter/splunk-audit-exporter@sha256:9ea4e347b1d7859cda0d2ce21dfcee8a78a0f8c89ac1b7a154e2dcfbba2179c1 # 0c9dd75
                 imagePullPolicy: Always
                 securityContext:
-                  privileged: true
+                  allowPrivilegeEscalation: false
+                  capabilities:
+                    drop:
+                    - ALL
+                  privileged: false
+                  readOnlyRootFilesystem: true
                   runAsUser: 0
+                  seLinuxOptions:
+                    type: container_logwriter_t
                 volumeMounts:
                 - mountPath: /config
                   name: config
-                - mountPath: /var/log
-                  name: logs
+                  readOnly: true
+                - mountPath: /var/log/kube-apiserver
+                  name: kube-apiserver-logs
+                  readOnly: true
+                - mountPath: /var/log/openshift-apiserver
+                  name: openshift-apiserver-logs
+                  readOnly: true
+                - mountPath: /var/log/oauth-apiserver
+                  name: oauth-apiserver-logs
+                  readOnly: true
+                - mountPath: /var/log/osd-audit
+                  name: osd-audit-logs
                 - mountPath: /certs
                   name: tls-certs-secret
                   readOnly: true
+                - mountPath: /tmp
+                  name: tmp
               nodeSelector:
                 node-role.kubernetes.io/master: ''
               restartPolicy: Always
@@ -857,10 +876,24 @@ objects:
               - name: tls-certs-secret
                 secret:
                   secretName: audit-exporter-certs
-              - name: logs
+              - name: kube-apiserver-logs
                 hostPath:
-                  type: Directory
-                  path: /var/log
+                  path: /var/log/kube-apiserver
+                  type: DirectoryOrCreate
+              - name: openshift-apiserver-logs
+                hostPath:
+                  path: /var/log/openshift-apiserver
+                  type: DirectoryOrCreate
+              - name: oauth-apiserver-logs
+                hostPath:
+                  path: /var/log/oauth-apiserver
+                  type: DirectoryOrCreate
+              - name: osd-audit-logs
+                hostPath:
+                  path: /var/log/osd-audit
+                  type: DirectoryOrCreate
+              - name: tmp
+                emptyDir: {}
       - apiVersion: v1
         kind: Service
         metadata:

--- a/pkg/kube/audit_exporter_template_test.go
+++ b/pkg/kube/audit_exporter_template_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 	k8syaml "k8s.io/apimachinery/pkg/util/yaml"
 )
 
@@ -131,8 +132,17 @@ func TestAuditExporterSecurityContext(t *testing.T) {
 			if sc.ReadOnlyRootFilesystem == nil || !*sc.ReadOnlyRootFilesystem {
 				t.Error("audit-exporter must set readOnlyRootFilesystem=true")
 			}
-			if sc.Capabilities == nil || len(sc.Capabilities.Drop) == 0 {
-				t.Error("audit-exporter must drop capabilities")
+			foundDropAll := false
+			if sc.Capabilities != nil {
+				for _, cap := range sc.Capabilities.Drop {
+					if cap == corev1.Capability("ALL") {
+						foundDropAll = true
+						break
+					}
+				}
+			}
+			if !foundDropAll {
+				t.Error("audit-exporter must drop ALL capabilities")
 			}
 		})
 	}
@@ -164,11 +174,15 @@ func TestAuditExporterVolumeMounts(t *testing.T) {
 				}
 			}
 
-			if _, ok := mountPaths["/var/log/osd-audit"]; !ok {
+			if ro, ok := mountPaths["/var/log/osd-audit"]; !ok {
 				t.Error("missing writable mount /var/log/osd-audit")
+			} else if ro {
+				t.Error("/var/log/osd-audit must be writable (exporter output directory)")
 			}
-			if _, ok := mountPaths["/tmp"]; !ok {
+			if ro, ok := mountPaths["/tmp"]; !ok {
 				t.Error("missing /tmp mount (needed for readOnlyRootFilesystem)")
+			} else if ro {
+				t.Error("/tmp must be writable (scratch space for readOnlyRootFilesystem)")
 			}
 			if _, ok := mountPaths["/var/log"]; ok {
 				t.Error("audit-exporter must not mount the entire /var/log")
@@ -203,9 +217,9 @@ func TestAuditExporterHostPathVolumes(t *testing.T) {
 				}
 			}
 
-			for name, path := range hostPaths {
-				if path == "/var/log" || path == "/" {
-					t.Errorf("volume %q must not mount broad path %q", name, path)
+			for name := range hostPaths {
+				if _, allowed := expectedHostPaths[name]; !allowed {
+					t.Errorf("unexpected hostPath volume %q not in allow-list", name)
 				}
 			}
 		})

--- a/pkg/kube/audit_exporter_template_test.go
+++ b/pkg/kube/audit_exporter_template_test.go
@@ -113,6 +113,150 @@ func TestAuditExporterServiceAccountName(t *testing.T) {
 	}
 }
 
+func TestAuditExporterSecurityContext(t *testing.T) {
+	for _, ds := range loadAuditExporterDaemonSets(t) {
+		t.Run(ds.name, func(t *testing.T) {
+			container := ds.ds.Spec.Template.Spec.Containers[0]
+			sc := container.SecurityContext
+
+			if sc == nil {
+				t.Fatal("audit-exporter container has no securityContext")
+			}
+			if sc.Privileged == nil || *sc.Privileged {
+				t.Error("audit-exporter must not be privileged")
+			}
+			if sc.AllowPrivilegeEscalation == nil || *sc.AllowPrivilegeEscalation {
+				t.Error("audit-exporter must set allowPrivilegeEscalation=false")
+			}
+			if sc.ReadOnlyRootFilesystem == nil || !*sc.ReadOnlyRootFilesystem {
+				t.Error("audit-exporter must set readOnlyRootFilesystem=true")
+			}
+			if sc.Capabilities == nil || len(sc.Capabilities.Drop) == 0 {
+				t.Error("audit-exporter must drop capabilities")
+			}
+		})
+	}
+}
+
+func TestAuditExporterVolumeMounts(t *testing.T) {
+	for _, ds := range loadAuditExporterDaemonSets(t) {
+		t.Run(ds.name, func(t *testing.T) {
+			container := ds.ds.Spec.Template.Spec.Containers[0]
+
+			mountPaths := map[string]bool{}
+			for _, vm := range container.VolumeMounts {
+				mountPaths[vm.MountPath] = vm.ReadOnly
+			}
+
+			readOnlyMounts := []string{
+				"/var/log/kube-apiserver",
+				"/var/log/openshift-apiserver",
+				"/var/log/oauth-apiserver",
+				"/config",
+				"/certs",
+			}
+			for _, m := range readOnlyMounts {
+				ro, ok := mountPaths[m]
+				if !ok {
+					t.Errorf("missing expected mount %s", m)
+				} else if !ro {
+					t.Errorf("mount %s should be readOnly", m)
+				}
+			}
+
+			if _, ok := mountPaths["/var/log/osd-audit"]; !ok {
+				t.Error("missing writable mount /var/log/osd-audit")
+			}
+			if _, ok := mountPaths["/tmp"]; !ok {
+				t.Error("missing /tmp mount (needed for readOnlyRootFilesystem)")
+			}
+			if _, ok := mountPaths["/var/log"]; ok {
+				t.Error("audit-exporter must not mount the entire /var/log")
+			}
+		})
+	}
+}
+
+func TestAuditExporterHostPathVolumes(t *testing.T) {
+	expectedHostPaths := map[string]string{
+		"kube-apiserver-logs":      "/var/log/kube-apiserver",
+		"openshift-apiserver-logs": "/var/log/openshift-apiserver",
+		"oauth-apiserver-logs":     "/var/log/oauth-apiserver",
+		"osd-audit-logs":           "/var/log/osd-audit",
+	}
+
+	for _, ds := range loadAuditExporterDaemonSets(t) {
+		t.Run(ds.name, func(t *testing.T) {
+			hostPaths := map[string]string{}
+			for _, vol := range ds.ds.Spec.Template.Spec.Volumes {
+				if vol.HostPath != nil {
+					hostPaths[vol.Name] = vol.HostPath.Path
+				}
+			}
+
+			for name, wantPath := range expectedHostPaths {
+				gotPath, ok := hostPaths[name]
+				if !ok {
+					t.Errorf("missing hostPath volume %q", name)
+				} else if gotPath != wantPath {
+					t.Errorf("volume %q hostPath = %q, want %q", name, gotPath, wantPath)
+				}
+			}
+
+			for name, path := range hostPaths {
+				if path == "/var/log" || path == "/" {
+					t.Errorf("volume %q must not mount broad path %q", name, path)
+				}
+			}
+		})
+	}
+}
+
+type auditExporterDS struct {
+	name string
+	ds   *appsv1.DaemonSet
+}
+
+func loadAuditExporterDaemonSets(t *testing.T) []auditExporterDS {
+	t.Helper()
+	templateParamRe := regexp.MustCompile(`\$\{\{[^}]+\}\}`)
+
+	templateFiles := []string{
+		"hack/olm-registry/olm-artifacts-template.yaml",
+		"hack/pko/clusterpackage.yaml",
+	}
+
+	results := make([]auditExporterDS, 0, len(templateFiles))
+	for _, templateFile := range templateFiles {
+		path := filepath.Join("..", "..", templateFile)
+		raw, err := os.ReadFile(path) // #nosec G304 -- path is a hardcoded test fixture
+		if err != nil {
+			t.Fatalf("failed to read template %s: %v", templateFile, err)
+		}
+
+		cleaned := templateParamRe.ReplaceAll(raw, []byte(`"__PLACEHOLDER__"`))
+
+		jsonBytes, err := k8syaml.ToJSON(cleaned)
+		if err != nil {
+			t.Fatalf("failed to convert YAML to JSON: %v", err)
+		}
+
+		var parsed any
+		if err := json.Unmarshal(jsonBytes, &parsed); err != nil {
+			t.Fatalf("failed to parse template: %v", err)
+		}
+
+		for _, ds := range findAuditExporterDaemonSets(t, parsed) {
+			results = append(results, auditExporterDS{name: templateFile, ds: ds})
+		}
+	}
+
+	if len(results) == 0 {
+		t.Fatal("no audit-exporter DaemonSets found in templates")
+	}
+	return results
+}
+
 func TestAuditExporterSCCUserMatch(t *testing.T) {
 	sccFiles := []string{
 		"hack/olm-registry/olm-artifacts-template.yaml",


### PR DESCRIPTION
## Summary

- Scope the audit-exporter container's volume mounts to only the directories it needs
- Update securityContext to follow current best practices

No functional change to log paths or exporter behaviour.

## Test plan

- [x] `TestAuditExporterServiceAccountName` passes
- [x] `TestAuditExporterSCCUserMatch` passes
- [x] Verify audit-exporter pods start and forward logs on a staging cluster

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security Enhancements**
  * Hardened the audit exporter with restricted container privileges, dropped capabilities, disabled privilege escalation, and a read-only root filesystem.
  * Limited log access to required API server and audit-log directories.
  * Added controlled temporary writable storage and SELinux labeling.
* **Bug Fixes**
  * Prevented broad host log and root filesystem mounts through stricter volume configuration.
* **Tests**
  * Added coverage to verify security settings, volume restrictions, and required paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->