### PR TITLE
Drop core v1 events from audit policy

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -3,7 +3,7 @@ COPY . /go/src/github.com/openshift/splunk-forwarder-operator
 WORKDIR /go/src/github.com/openshift/splunk-forwarder-operator
 RUN make go-build
 
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.8-1787647261
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.8-1788166357
 ENV OPERATOR_PATH=/go/src/github.com/openshift/splunk-forwarder-operator \
     OPERATOR_BIN=splunk-forwarder-operator
 

--- a/build/Dockerfile.olm-registry
+++ b/build/Dockerfile.olm-registry
@@ -4,7 +4,7 @@ COPY ${SAAS_OPERATOR_DIR} manifests
 RUN initializer --permissive
 
 # ubi-micro does not work for clusters with fips enabled unless we make OpenSSL available
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.8-1787647261
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.8-1788166357
 
 COPY --from=builder /bin/registry-server /bin/registry-server
 COPY --from=builder /bin/grpc_health_probe /bin/grpc_health_probe

--- a/hack/pko/clusterpackage.yaml
+++ b/hack/pko/clusterpackage.yaml
@@ -1437,10 +1437,12 @@ objects:
                 - imagestreams
                 - imagestreamimports
               verbs: ['create','update']
-            # drop events.events.k8s.io
+            # drop events (both events.k8s.io and core v1)
             - level: None
               resources:
               - group: events.k8s.io
+                resources: ['events']
+              - group: ''
                 resources: ['events']
             # drop noisy namespace reads
             - level: None


### PR DESCRIPTION
## Summary

- The existing audit policy drop rule only filters `events.k8s.io/events` but not core `v1/events` (empty apiGroup). Core v1 events (kubelet/SA event creates and patches) account for ~15M audit entries/day (~26% of total Splunk ingestion volume).
- Adds `group: ''` with `resources: ['events']` alongside the existing `events.k8s.io` rule so both API groups are dropped.

Context: [HCMSEC-3645](https://redhat.atlassian.net/browse/HCMSEC-3645), [Slack thread](https://redhat-internal.slack.com/archives/C0A8S4L99C2/p1785875792427419)

## Test plan

- [ ] Verify audit policy YAML is valid
- [ ] Confirm `objectRef.resource=events` volume drops in Splunk after rollout
- [ ] Verify actual audit log entries (non-Event resources) are unaffected

[HCMSEC-3645]: https://redhat.atlassian.net/browse/HCMSEC-3645?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the standard audit policy to exclude both core Kubernetes events and `events.k8s.io` events from event-drop processing.
  * Event-forwarding audit behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->