### PR TITLE
Add audit log filters to all SplunkForwarder CRs

### DIFF
--- a/hack/pko/clusterpackage.yaml
+++ b/hack/pko/clusterpackage.yaml
@@ -235,6 +235,17 @@ objects:
           image: quay.io/redhat-services-prod/openshift/splunk-forwarder-images
           imageDigest: sha256:74b6a7e80da95b5bde5d7aade76d306b383430fc9a73f0b650ffaddf87b9a784
           splunkLicenseAccepted: true
+          filters:
+          - name: ignore_serviceaccount_users
+            filter: '"user":{"username":"(?:system:serviceaccount:(?!openshift-backplane-)[^"]+)'
+          - name: ignore_system_node_users
+            filter: '"user":{"username":"system:node:[^"]+"'
+          - name: ignore_chatty_system_users
+            filter: '"user":{"username":"system:(?:kube-(?:controller-manager|scheduler|apiserver-cert-syncer)|apiserver|aggregator)"'
+          - name: ignore_well_known_oauth_endpoint
+            filter: '"requestURI":"/.well-known/oauth-authorization-server"'
+          - name: ignore_livez_health_check
+            filter: '"requestURI":"/livez"'
           splunkInputs:
           - path: /host/var/log/pods/*_ip-*-*-*-*ec2internal-debug_*/container-*/*.log
             index: openshift_managed_debug_node
@@ -293,6 +304,17 @@ objects:
             image: quay.io/redhat-services-prod/openshift/splunk-forwarder-images
             imageDigest: sha256:74b6a7e80da95b5bde5d7aade76d306b383430fc9a73f0b650ffaddf87b9a784
             splunkLicenseAccepted: true
+            filters:
+              - name: ignore_serviceaccount_users
+                filter: '"user":{"username":"(?:system:serviceaccount:(?!openshift-backplane-)[^"]+)'
+              - name: ignore_system_node_users
+                filter: '"user":{"username":"system:node:[^"]+"'
+              - name: ignore_chatty_system_users
+                filter: '"user":{"username":"system:(?:kube-(?:controller-manager|scheduler|apiserver-cert-syncer)|apiserver|aggregator)"'
+              - name: ignore_well_known_oauth_endpoint
+                filter: '"requestURI":"/.well-known/oauth-authorization-server"'
+              - name: ignore_livez_health_check
+                filter: '"requestURI":"/livez"'
             splunkInputs:
               - path: /host/var/log/hypershift-osd-audit/*/audit.log
                 index: openshift_managed_hypershift_audit_stage
@@ -455,6 +477,17 @@ objects:
             image: quay.io/redhat-services-prod/openshift/splunk-forwarder-images
             imageDigest: sha256:74b6a7e80da95b5bde5d7aade76d306b383430fc9a73f0b650ffaddf87b9a784
             splunkLicenseAccepted: true
+            filters:
+              - name: ignore_serviceaccount_users
+                filter: '"user":{"username":"(?:system:serviceaccount:(?!openshift-backplane-)[^"]+)'
+              - name: ignore_system_node_users
+                filter: '"user":{"username":"system:node:[^"]+"'
+              - name: ignore_chatty_system_users
+                filter: '"user":{"username":"system:(?:kube-(?:controller-manager|scheduler|apiserver-cert-syncer)|apiserver|aggregator)"'
+              - name: ignore_well_known_oauth_endpoint
+                filter: '"requestURI":"/.well-known/oauth-authorization-server"'
+              - name: ignore_livez_health_check
+                filter: '"requestURI":"/livez"'
             splunkInputs:
               - path: /host/var/log/hypershift-osd-audit/*/audit.log
                 index: rh_osd_hypershift_audit_stage
@@ -714,6 +747,17 @@ objects:
           image: quay.io/redhat-services-prod/openshift/splunk-forwarder-images
           imageDigest: sha256:74b6a7e80da95b5bde5d7aade76d306b383430fc9a73f0b650ffaddf87b9a784
           splunkLicenseAccepted: true
+          filters:
+          - name: ignore_serviceaccount_users
+            filter: '"user":{"username":"(?:system:serviceaccount:(?!openshift-backplane-)[^"]+)'
+          - name: ignore_system_node_users
+            filter: '"user":{"username":"system:node:[^"]+"'
+          - name: ignore_chatty_system_users
+            filter: '"user":{"username":"system:(?:kube-(?:controller-manager|scheduler|apiserver-cert-syncer)|apiserver|aggregator)"'
+          - name: ignore_well_known_oauth_endpoint
+            filter: '"requestURI":"/.well-known/oauth-authorization-server"'
+          - name: ignore_livez_health_check
+            filter: '"requestURI":"/livez"'
           splunkInputs:
           - index: rh_osd_cluster_audit_stage
             path: /host/var/log/osd-audit/audit.log


### PR DESCRIPTION
## Summary
- Adds the same 5 audit log filters to all 4 staging SplunkForwarder CRs (non-HCP, HCP, FedRAMP HCP, FedRAMP non-HCP)
- Production CRs already had these filters; staging was missing them, so the UF filter transforms from #485 had no effect on staging clusters
- With this change, audit log filtering is enabled across all environments and cluster types

Filters applied:
1. `ignore_serviceaccount_users` - drop non-backplane service account events
2. `ignore_system_node_users` - drop system:node user events
3. `ignore_chatty_system_users` - drop kube-controller-manager, scheduler, apiserver, aggregator events
4. `ignore_well_known_oauth_endpoint` - drop oauth discovery endpoint events
5. `ignore_livez_health_check` - drop /livez health check events

## Test plan
- [ ] Verify staging HCP SC picks up filters after sync (check `osd-monitored-logs-local` configmap for `transforms.conf`)
- [ ] Query Splunk staging index to confirm SA/node events are being filtered
- [ ] Monitor for any audit log gaps or unexpected drops

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Improved Splunk event filtering for staging and FedRAMP environments.
  - Reduced logging noise by excluding routine service-account, system-node, control-plane, OAuth discovery, and health-check events.
  - Retained visibility for relevant backplane account activity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->