### PR TITLE
Update Go version to 1.26.8

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/openshift/splunk-forwarder-operator
 
-go 1.26.0
+go 1.26.8
 
 require (
 	github.com/onsi/ginkgo/v2 v2.32.1


### PR DESCRIPTION
https://redhat.atlassian.net/browse/ROSAENG-66308 - Update minimum Go version from 1.26.0 to 1.26.8.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the required Go version to 1.26.8.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->