### PR TITLE
HCMSEC-3645: Fix configmap reconciliation when operator code changes

### DIFF
--- a/controllers/splunkforwarder/splunkforwarder_controller.go
+++ b/controllers/splunkforwarder/splunkforwarder_controller.go
@@ -2,6 +2,7 @@ package splunkforwarder
 
 import (
 	"context"
+	"reflect"
 	"strconv"
 
 	"github.com/go-logr/logr"
@@ -114,18 +115,20 @@ func (r *SplunkForwarderReconciler) Reconcile(ctx context.Context, request ctrl.
 
 		// Check if this ConfigMap already exists
 		cmFound := &corev1.ConfigMap{}
-		err = r.Client.Get(context.TODO(), types.NamespacedName{Name: configmap.Name, Namespace: configmap.Namespace}, cmFound)
+		err = r.Client.Get(ctx, types.NamespacedName{Name: configmap.Name, Namespace: configmap.Namespace}, cmFound)
 		if err != nil && errors.IsNotFound(err) {
 			r.ReqLogger.Info("Creating a new ConfigMap", "ConfigMap.Namespace", configmap.Namespace, "ConfigMap.Name", configmap.Name)
-			err = r.Client.Create(context.TODO(), configmap)
+			err = r.Client.Create(ctx, configmap)
 			if err != nil {
 				return reconcile.Result{}, err
 			}
 		} else if err != nil {
 			return reconcile.Result{}, err
-		} else if instance.CreationTimestamp.After(cmFound.CreationTimestamp.Time) || r.CheckGenerationVersionOlder(cmFound.GetAnnotations(), instance) {
+		} else if instance.CreationTimestamp.After(cmFound.CreationTimestamp.Time) || r.CheckGenerationVersionOlder(cmFound.GetAnnotations(), instance) || !reflect.DeepEqual(cmFound.Data, configmap.Data) {
 			r.ReqLogger.Info("Updating ConfigMap", "ConfigMap.Namespace", configmap.Namespace, "ConfigMap.Name", configmap.Name)
-			err = r.Client.Update(context.TODO(), configmap)
+			cmFound.Data = configmap.Data
+			cmFound.Annotations = configmap.Annotations
+			err = r.Client.Update(ctx, cmFound)
 			if err != nil {
 				return reconcile.Result{}, err
 			}

--- a/controllers/splunkforwarder/splunkforwarder_controller_test.go
+++ b/controllers/splunkforwarder/splunkforwarder_controller_test.go
@@ -2,13 +2,16 @@ package splunkforwarder
 
 import (
 	"context"
+	"fmt"
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 
 	configv1 "github.com/openshift/api/config/v1"
 	sfv1alpha1 "github.com/openshift/splunk-forwarder-operator/api/v1alpha1"
 	"github.com/openshift/splunk-forwarder-operator/config"
+	"github.com/openshift/splunk-forwarder-operator/pkg/kube"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -193,5 +196,102 @@ func TestReconcileSplunkForwarder_Reconcile(t *testing.T) {
 				t.Errorf("ReconcileSplunkForwarder.Reconcile() = %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestReconcileUpdatesStaleConfigMap(t *testing.T) {
+	if err := sfv1alpha1.AddToScheme(scheme.Scheme); err != nil {
+		t.Fatal(err)
+	}
+	if err := configv1.AddToScheme(scheme.Scheme); err != nil {
+		t.Fatal(err)
+	}
+
+	cr := &sfv1alpha1.SplunkForwarder{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "SplunkForwarder",
+			APIVersion: "splunkforwarder.managed.openshift.io/v1alpha1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       instanceName,
+			Namespace:  instanceNamespace,
+			Generation: 37,
+		},
+		Spec: sfv1alpha1.SplunkForwarderSpec{
+			SplunkLicenseAccepted: true,
+			Image:                 image,
+			ImageTag:              imageTag,
+			SplunkInputs: []sfv1alpha1.SplunkForwarderInputs{
+				{Path: "/var/log/audit.log", Index: "audit"},
+			},
+			Filters: []sfv1alpha1.SplunkFilter{
+				{Name: "ignore_sa", Filter: `"user":{"username":"system:serviceaccount:[^"]+"}`},
+			},
+		},
+	}
+
+	staleCM := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "osd-monitored-logs-local",
+			Namespace: instanceNamespace,
+			Annotations: map[string]string{
+				"genVersion": "37",
+			},
+			Labels: map[string]string{"app": instanceName},
+		},
+		Data: map[string]string{
+			"app.conf":    "old",
+			"inputs.conf": "old",
+			"props.conf":  fmt.Sprintf("\n[_json]\nTRUNCATE = %d\n", kube.MaxEventSize),
+		},
+	}
+
+	metaCM := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "osd-monitored-logs-metadata",
+			Namespace: instanceNamespace,
+			Annotations: map[string]string{
+				"genVersion": "37",
+			},
+			Labels: map[string]string{"app": instanceName},
+		},
+		Data: map[string]string{
+			"local.meta": "\n[]\naccess = read : [ * ], write : [ admin ]\nexport = system\n",
+		},
+	}
+
+	fakeClient := fakekubeclient.NewClientBuilder().
+		WithScheme(scheme.Scheme).
+		WithRuntimeObjects(cr, testSplunkForwarderSecret(), staleCM, metaCM).
+		Build()
+
+	r := &SplunkForwarderReconciler{
+		Client:    fakeClient,
+		Scheme:    scheme.Scheme,
+		ReqLogger: log.WithValues(),
+	}
+
+	req := reconcile.Request{
+		NamespacedName: types.NamespacedName{Name: instanceName, Namespace: instanceNamespace},
+	}
+
+	result, err := r.Reconcile(context.TODO(), req)
+	if err != nil {
+		t.Fatalf("Reconcile() error = %v", err)
+	}
+	if result == (reconcile.Result{}) {
+		t.Error("expected non-empty reconcile result after updating stale configmap")
+	}
+
+	updated := &corev1.ConfigMap{}
+	err = fakeClient.Get(context.TODO(), types.NamespacedName{Name: "osd-monitored-logs-local", Namespace: instanceNamespace}, updated)
+	if err != nil {
+		t.Fatalf("failed to get updated configmap: %v", err)
+	}
+	if _, ok := updated.Data["transforms.conf"]; !ok {
+		t.Error("expected transforms.conf in updated configmap")
+	}
+	if !strings.Contains(updated.Data["props.conf"], "TRANSFORMS-null") {
+		t.Error("expected TRANSFORMS-null in updated props.conf")
 	}
 }

--- a/test/e2e/splunk_forwarder_operator_tests.go
+++ b/test/e2e/splunk_forwarder_operator_tests.go
@@ -626,6 +626,83 @@ var _ = ginkgo.Describe("Splunk Forwarder Operator", ginkgo.Ordered, func() {
 			"ConfigMaps should be deleted when CR is deleted")
 	})
 
+	ginkgo.It("reconciles configmap when content is stale but genVersion matches", func(ctx context.Context) {
+		crName := "test-stale-cm-reconcile"
+
+		ginkgo.By("creating SplunkForwarder CR with filters")
+		sf := sfv1alpha1.SplunkForwarder{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      crName,
+				Namespace: operatorNamespace,
+			},
+			Spec: sfv1alpha1.SplunkForwarderSpec{
+				SplunkLicenseAccepted: true,
+				Image:                 "quay.io/redhat-services-prod/openshift/splunk-forwarder-images",
+				ImageTag:              "latest",
+				ClusterID:             "stale-cm-test",
+				SplunkInputs: []sfv1alpha1.SplunkForwarderInputs{
+					{
+						Path:       "/var/log/audit.log",
+						Index:      "audit",
+						SourceType: "_json",
+					},
+				},
+				Filters: []sfv1alpha1.SplunkFilter{
+					{Name: "ignore_sa_users", Filter: `"user":{"username":"system:serviceaccount:[^"]+"}`},
+					{Name: "ignore_livez", Filter: `"requestURI":"/livez"`},
+				},
+			},
+		}
+		Expect(k8s.WithNamespace(operatorNamespace).Create(ctx, &sf)).To(Succeed())
+
+		defer func() {
+			k8s.WithNamespace(operatorNamespace).Delete(ctx, &sf)
+			time.Sleep(3 * time.Second)
+		}()
+
+		ginkgo.By("waiting for configmap to be created with transforms")
+		var localCM corev1.ConfigMap
+		Eventually(func() bool {
+			err := k8s.Get(ctx, "osd-monitored-logs-local", operatorNamespace, &localCM)
+			if err != nil {
+				return false
+			}
+			_, hasTransforms := localCM.Data["transforms.conf"]
+			return hasTransforms && strings.Contains(localCM.Data["props.conf"], "TRANSFORMS-null")
+		}).WithTimeout(60*time.Second).WithPolling(5*time.Second).Should(BeTrue(),
+			"configmap should contain transforms.conf and TRANSFORMS-null")
+
+		ginkgo.By("verifying transforms.conf has correct filter stanzas")
+		transforms := localCM.Data["transforms.conf"]
+		Expect(transforms).To(ContainSubstring("[filter_ignore_sa_users]"))
+		Expect(transforms).To(ContainSubstring("[filter_ignore_livez]"))
+		Expect(transforms).To(ContainSubstring("DEST_KEY = queue"))
+		Expect(transforms).To(ContainSubstring("FORMAT = nullQueue"))
+
+		ginkgo.By("simulating stale configmap by removing transforms (preserving genVersion)")
+		err := k8s.Get(ctx, "osd-monitored-logs-local", operatorNamespace, &localCM)
+		Expect(err).NotTo(HaveOccurred())
+		delete(localCM.Data, "transforms.conf")
+		localCM.Data["props.conf"] = "\n[_json]\nTRUNCATE = 102400\n"
+		Expect(k8s.Update(ctx, &localCM)).To(Succeed())
+
+		ginkgo.By("verifying reconciler detects content change and restores transforms")
+		Eventually(func() bool {
+			err := k8s.Get(ctx, "osd-monitored-logs-local", operatorNamespace, &localCM)
+			if err != nil {
+				return false
+			}
+			_, hasTransforms := localCM.Data["transforms.conf"]
+			return hasTransforms && strings.Contains(localCM.Data["props.conf"], "TRANSFORMS-null")
+		}).WithTimeout(90*time.Second).WithPolling(5*time.Second).Should(BeTrue(),
+			"reconciler should restore transforms.conf when content drifts")
+
+		ginkgo.By("verifying restored transforms has correct content")
+		Expect(localCM.Data["transforms.conf"]).To(ContainSubstring("[filter_ignore_sa_users]"))
+		Expect(localCM.Data["transforms.conf"]).To(ContainSubstring("[filter_ignore_livez]"))
+		Expect(localCM.Data["props.conf"]).To(ContainSubstring("TRANSFORMS-null"))
+	})
+
 	ginkgo.It("DaemonSet uses correct ServiceAccount for SCC access", func(ctx context.Context) {
 		crName := "test-sa-config"
 


### PR DESCRIPTION
## Summary

- Fix a reconciliation gap where configmaps were not updated after an operator code change if the CR generation hadn't changed
- The configmap update check used strict less-than on genVersion vs CR generation, which missed the case where an old operator reconciled a new CR first (setting genVersion to match) before the new operator pod started
- Add reflect.DeepEqual content comparison to detect stale configmap data regardless of genVersion
- Use the found configmap object (which has resourceVersion) for updates instead of the generated object

**Root cause**: When the SFO promotion simultaneously delivered new filters in the CR and new filter-rendering code in the operator image, the old operator reconciled the CR first. It wrote genVersion=37 to the configmap without transforms.conf (old code had no filter logic). The new operator then saw genVersion matched generation and skipped the update, leaving filters unapplied on all canary clusters.

Jira: https://redhat.atlassian.net/browse/HCMSEC-3645

## Test plan

- [x] Unit test TestReconcileUpdatesStaleConfigMap verifies the reconciler detects and updates a configmap with matching genVersion but stale content
- [x] E2e test "reconciles configmap when content is stale but genVersion matches" creates a CR with filters, simulates content drift by removing transforms.conf, and verifies the reconciler restores it
- [x] All 60 existing unit tests pass
- [x] E2e tests compile with osde2e build tag


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Stale configuration data is now detected and refreshed automatically, even when the configuration version remains unchanged.
  - Generated transform settings and related metadata are restored when missing or outdated.
  - Reconciliation now reliably persists refreshed configuration changes, helping ensure deployed settings match the expected configuration.

- **Tests**
  - Added unit and end-to-end coverage for stale configuration reconciliation and restoration of generated transform settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->